### PR TITLE
Bump version to 0.1.2

### DIFF
--- a/arbi/Cargo.toml
+++ b/arbi/Cargo.toml
@@ -18,7 +18,7 @@ license = "Apache-2.0 OR MIT"
 name = "arbi"
 readme = "README.md"
 repository = "https://github.com/OTheDev/arbi"
-version = "0.1.1"
+version = "0.1.2"
 
 [dependencies]
 


### PR DESCRIPTION
* Added explicit links to README for GitHub and crates.io docs

Bump so that the README links work in the crates.io documentation.