### PR TITLE
Add module with impl. of builtin int methods

### DIFF
--- a/arbi/src/builtin_int_methods/count_ones.rs
+++ b/arbi/src/builtin_int_methods/count_ones.rs
@@ -1,0 +1,85 @@
+/*
+Copyright 2024 Owain Davies
+SPDX-License-Identifier: Apache-2.0 OR MIT
+*/
+
+use crate::Arbi;
+
+impl Arbi {
+    /// Returns the number of ones in the binary representation of the absolute
+    /// value of `self`.
+    ///
+    /// # Examples
+    /// ```
+    /// use arbi::Arbi;
+    ///
+    /// let a = Arbi::from(0b01001100u32);
+    /// assert_eq!(a.count_ones(), 3);
+    ///
+    /// let max_u64 = Arbi::from(u64::MAX);
+    /// assert_eq!(max_u64.count_ones(), 64);
+    ///
+    /// let zero = Arbi::zero();
+    /// assert_eq!(zero.count_ones(), 0);
+    /// ```
+    ///
+    /// ## Complexity
+    /// \\( O(n) \\)
+    pub fn count_ones(&self) -> u128 {
+        self.vec.iter().map(|x| x.count_ones() as u128).sum()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::util::test::{get_seedable_rng, get_uniform_die, Distribution};
+    use crate::{Arbi, Assign};
+    use crate::{DDigit, Digit, QDigit};
+
+    #[test]
+    fn smoke() {
+        let (mut rng, _) = get_seedable_rng();
+        let die_d = get_uniform_die(Digit::MIN, Digit::MAX);
+        let die_dd = get_uniform_die(Digit::MAX as DDigit + 1, DDigit::MAX);
+
+        for _ in 0..i16::MAX {
+            let digit = die_d.sample(&mut rng);
+            let digit_arbi = Arbi::from(digit);
+            assert_eq!(digit_arbi.count_ones(), digit.count_ones() as u128);
+
+            let ddigit = die_dd.sample(&mut rng);
+            let ddigit_arbi = Arbi::from(ddigit);
+            assert_eq!(ddigit_arbi.count_ones(), ddigit.count_ones() as u128);
+        }
+    }
+
+    #[test]
+    fn boundaries() {
+        let zero = Arbi::zero();
+        assert_eq!(zero.count_ones(), 0_u32.count_ones() as u128);
+
+        let mut a = Arbi::from(Digit::MAX - 1);
+        assert_eq!(a.count_ones(), (Digit::MAX - 1).count_ones() as u128);
+
+        a.assign(Digit::MAX);
+        assert_eq!(a.count_ones(), Digit::MAX.count_ones() as u128);
+
+        a.incr();
+        assert_eq!(
+            a.count_ones(),
+            (Digit::MAX as DDigit + 1).count_ones() as u128
+        );
+
+        a.assign(DDigit::MAX - 1);
+        assert_eq!(a.count_ones(), (DDigit::MAX - 1).count_ones() as u128);
+
+        a.assign(DDigit::MAX);
+        assert_eq!(a.count_ones(), DDigit::MAX.count_ones() as u128);
+
+        a.assign(DDigit::MAX as QDigit + 1);
+        assert_eq!(
+            a.count_ones(),
+            (DDigit::MAX as QDigit + 1).count_ones() as u128
+        );
+    }
+}

--- a/arbi/src/builtin_int_methods/leading_ones.rs
+++ b/arbi/src/builtin_int_methods/leading_ones.rs
@@ -1,0 +1,96 @@
+/*
+Copyright 2024 Owain Davies
+SPDX-License-Identifier: Apache-2.0 OR MIT
+*/
+
+use crate::{Arbi, Digit};
+
+impl Arbi {
+    /// Returns the number of leading ones in the binary representation of the
+    /// absolute value of `self`.
+    ///
+    /// # Examples
+    /// ```
+    /// use arbi::Arbi;
+    ///
+    /// let zero = Arbi::zero();
+    /// assert_eq!(zero.leading_ones(), 0);
+    ///
+    /// let a = Arbi::from(u128::MAX);
+    /// assert_eq!(a.leading_ones(), 128);
+    ///
+    /// let b = Arbi::from(u128::MAX - 1);
+    /// assert_eq!(b.leading_ones(), 127);
+    /// ```
+    ///
+    /// ## Complexity
+    /// \\( O(n) \\)
+    pub fn leading_ones(&self) -> u128 {
+        let mut sum = 0_u128;
+        for x in self.vec.iter().rev() {
+            let leading_ones = x.leading_ones() as u128;
+            sum += leading_ones;
+            if leading_ones != Digit::BITS as u128 {
+                break;
+            }
+        }
+        sum
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::util::test::{get_seedable_rng, get_uniform_die, Distribution};
+    use crate::{Arbi, Assign};
+    use crate::{DDigit, Digit, QDigit};
+
+    #[test]
+    fn smoke() {
+        let (mut rng, _) = get_seedable_rng();
+        let die_d = get_uniform_die(Digit::MIN, Digit::MAX);
+        let die_dd = get_uniform_die(Digit::MAX as DDigit + 1, DDigit::MAX);
+
+        for _ in 0..i16::MAX {
+            let digit = die_d.sample(&mut rng);
+            let digit_arbi = Arbi::from(digit);
+            assert_eq!(digit_arbi.leading_ones(), digit.leading_ones() as u128);
+
+            let ddigit = die_dd.sample(&mut rng);
+            let ddigit_arbi = Arbi::from(ddigit);
+            assert_eq!(
+                ddigit_arbi.leading_ones(),
+                ddigit.leading_ones() as u128
+            );
+        }
+    }
+
+    #[test]
+    fn boundaries() {
+        let zero = Arbi::zero();
+        assert_eq!(zero.leading_ones(), 0_u32.leading_ones() as u128);
+
+        let mut a = Arbi::from(Digit::MAX - 1);
+        assert_eq!(a.leading_ones(), (Digit::MAX - 1).leading_ones() as u128);
+
+        a.assign(Digit::MAX);
+        assert_eq!(a.leading_ones(), Digit::MAX.leading_ones() as u128);
+
+        a.incr();
+        assert_eq!(
+            a.leading_ones(),
+            (Digit::MAX as DDigit + 1).leading_ones() as u128
+        );
+
+        a.assign(DDigit::MAX - 1);
+        assert_eq!(a.leading_ones(), (DDigit::MAX - 1).leading_ones() as u128);
+
+        a.assign(DDigit::MAX);
+        assert_eq!(a.leading_ones(), DDigit::MAX.leading_ones() as u128);
+
+        a.assign(DDigit::MAX as QDigit + 1);
+        assert_eq!(
+            a.leading_ones(),
+            (DDigit::MAX as QDigit + 1).leading_ones() as u128
+        );
+    }
+}

--- a/arbi/src/builtin_int_methods/mod.rs
+++ b/arbi/src/builtin_int_methods/mod.rs
@@ -1,0 +1,10 @@
+/*
+Copyright 2024 Owain Davies
+SPDX-License-Identifier: Apache-2.0 OR MIT
+*/
+
+mod count_ones;
+mod leading_ones;
+mod reverse_bits;
+mod swap_bytes;
+mod trailing_ones;

--- a/arbi/src/builtin_int_methods/reverse_bits.rs
+++ b/arbi/src/builtin_int_methods/reverse_bits.rs
@@ -1,0 +1,92 @@
+/*
+Copyright 2024 Owain Davies
+SPDX-License-Identifier: Apache-2.0 OR MIT
+*/
+
+use crate::Arbi;
+
+impl Arbi {
+    /// Reverses the order of bits in the absolute value of the integer.
+    ///
+    /// The least significant bit becomes the most significant bit, second least
+    /// significant bit becomes second most-significant bit, etc.
+    ///
+    /// The sign remains unchanged.
+    ///
+    /// # Examples
+    /// ```
+    /// use arbi::Arbi;
+    ///
+    /// let a = Arbi::from(0x12345678_u32);
+    /// let b = a.reverse_bits();
+    ///
+    /// assert_eq!(b, 0x12345678_u32.reverse_bits());
+    /// ```
+    ///
+    /// ## Complexity
+    /// \\( O(n) \\)
+    pub fn reverse_bits(mut self) -> Self {
+        let len = self.vec.len();
+        for i in 0..(len / 2) {
+            self.vec[i] = self.vec[i].reverse_bits();
+            self.vec[len - 1 - i] = self.vec[len - 1 - i].reverse_bits();
+            self.vec.swap(i, len - 1 - i);
+        }
+        if len % 2 != 0 {
+            self.vec[len / 2] = self.vec[len / 2].reverse_bits();
+        }
+        self.trim();
+        self
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::util::test::{get_seedable_rng, get_uniform_die, Distribution};
+    use crate::Arbi;
+    use crate::{DDigit, Digit};
+
+    #[test]
+    fn smoke() {
+        let (mut rng, _) = get_seedable_rng();
+        let die_d = get_uniform_die(Digit::MIN, Digit::MAX);
+        let die_dd = get_uniform_die(Digit::MAX as DDigit + 1, DDigit::MAX);
+
+        for _ in 0..i16::MAX {
+            let digit = die_d.sample(&mut rng);
+            let digit_arbi = Arbi::from(digit);
+            assert_eq!(digit_arbi.reverse_bits(), digit.reverse_bits() as u128);
+
+            let ddigit = die_dd.sample(&mut rng);
+            let ddigit_arbi = Arbi::from(ddigit);
+            assert_eq!(
+                ddigit_arbi.reverse_bits(),
+                ddigit.reverse_bits() as u128
+            );
+        }
+    }
+
+    #[test]
+    fn boundaries() {
+        let zero = Arbi::zero();
+        assert_eq!(zero.reverse_bits(), 0_u32.reverse_bits() as u128);
+
+        let a = Arbi::from(Digit::MAX - 1);
+        assert_eq!(a.reverse_bits(), (Digit::MAX - 1).reverse_bits() as u128);
+
+        let a = Arbi::from(Digit::MAX);
+        assert_eq!(a.reverse_bits(), Digit::MAX.reverse_bits() as u128);
+
+        let a = Arbi::from(Digit::MAX as DDigit + 1);
+        assert_eq!(
+            a.clone().reverse_bits(),
+            (Digit::MAX as DDigit + 1).reverse_bits() as u128
+        );
+
+        let a = Arbi::from(DDigit::MAX - 1);
+        assert_eq!(a.reverse_bits(), (DDigit::MAX - 1).reverse_bits() as u128);
+
+        let a = Arbi::from(DDigit::MAX);
+        assert_eq!(a.reverse_bits(), DDigit::MAX.reverse_bits() as u128);
+    }
+}

--- a/arbi/src/builtin_int_methods/swap_bytes.rs
+++ b/arbi/src/builtin_int_methods/swap_bytes.rs
@@ -1,0 +1,86 @@
+/*
+Copyright 2024 Owain Davies
+SPDX-License-Identifier: Apache-2.0 OR MIT
+*/
+
+use crate::Arbi;
+
+impl Arbi {
+    /// Reverses the byte order of the absolute value of the integer.
+    ///
+    /// The sign remains unchanged.
+    ///
+    /// # Examples
+    /// ```
+    /// use arbi::Arbi;
+    ///
+    /// let a = Arbi::from(0x12345678_u32);
+    /// let b = a.swap_bytes();
+    ///
+    /// assert_eq!(b, 0x78563412);
+    /// ```
+    ///
+    /// ## Complexity
+    /// \\( O(n) \\)
+    pub fn swap_bytes(mut self) -> Self {
+        let len = self.vec.len();
+        for i in 0..(len / 2) {
+            self.vec[i] = self.vec[i].swap_bytes();
+            self.vec[len - 1 - i] = self.vec[len - 1 - i].swap_bytes();
+            self.vec.swap(i, len - 1 - i);
+        }
+        if len % 2 != 0 {
+            self.vec[len / 2] = self.vec[len / 2].swap_bytes();
+        }
+        self.trim();
+        self
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::util::test::{get_seedable_rng, get_uniform_die, Distribution};
+    use crate::Arbi;
+    use crate::{DDigit, Digit};
+
+    #[test]
+    fn smoke() {
+        let (mut rng, _) = get_seedable_rng();
+        let die_d = get_uniform_die(Digit::MIN, Digit::MAX);
+        let die_dd = get_uniform_die(Digit::MAX as DDigit + 1, DDigit::MAX);
+
+        for _ in 0..i16::MAX {
+            let digit = die_d.sample(&mut rng);
+            let digit_arbi = Arbi::from(digit);
+            assert_eq!(digit_arbi.swap_bytes(), digit.swap_bytes() as u128);
+
+            let ddigit = die_dd.sample(&mut rng);
+            let ddigit_arbi = Arbi::from(ddigit);
+            assert_eq!(ddigit_arbi.swap_bytes(), ddigit.swap_bytes() as u128);
+        }
+    }
+
+    #[test]
+    fn boundaries() {
+        let zero = Arbi::zero();
+        assert_eq!(zero.swap_bytes(), 0_u32.swap_bytes() as u128);
+
+        let a = Arbi::from(Digit::MAX - 1);
+        assert_eq!(a.swap_bytes(), (Digit::MAX - 1).swap_bytes() as u128);
+
+        let a = Arbi::from(Digit::MAX);
+        assert_eq!(a.swap_bytes(), Digit::MAX.swap_bytes() as u128);
+
+        let a = Arbi::from(Digit::MAX as DDigit + 1);
+        assert_eq!(
+            a.clone().swap_bytes(),
+            (Digit::MAX as DDigit + 1).swap_bytes() as u128
+        );
+
+        let a = Arbi::from(DDigit::MAX - 1);
+        assert_eq!(a.swap_bytes(), (DDigit::MAX - 1).swap_bytes() as u128);
+
+        let a = Arbi::from(DDigit::MAX);
+        assert_eq!(a.swap_bytes(), DDigit::MAX.swap_bytes() as u128);
+    }
+}

--- a/arbi/src/builtin_int_methods/trailing_ones.rs
+++ b/arbi/src/builtin_int_methods/trailing_ones.rs
@@ -1,0 +1,102 @@
+/*
+Copyright 2024 Owain Davies
+SPDX-License-Identifier: Apache-2.0 OR MIT
+*/
+
+use crate::{Arbi, Digit};
+
+impl Arbi {
+    /// Returns the number of trailing ones in the binary representation of the
+    /// absolute value of `self`.
+    ///
+    /// # Examples
+    /// ```
+    /// use arbi::Arbi;
+    ///
+    /// let zero = Arbi::zero();
+    /// assert_eq!(zero.trailing_ones(), 0);
+    ///
+    /// let a = Arbi::from(u128::MAX);
+    /// assert_eq!(a.trailing_ones(), 128);
+    ///
+    /// let b = Arbi::from(u128::MAX - 1);
+    /// assert_eq!(b.trailing_ones(), 0);
+    /// ```
+    ///
+    /// ## Complexity
+    /// \\( O(n) \\)
+    pub fn trailing_ones(&self) -> u128 {
+        let mut sum = 0_u128;
+        for x in self.vec.iter() {
+            let trailing_ones = x.trailing_ones() as u128;
+            sum += trailing_ones;
+            if trailing_ones != Digit::BITS as u128 {
+                break;
+            }
+        }
+        sum
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::util::test::{get_seedable_rng, get_uniform_die, Distribution};
+    use crate::{Arbi, Assign};
+    use crate::{DDigit, Digit, QDigit};
+
+    #[test]
+    fn smoke() {
+        let (mut rng, _) = get_seedable_rng();
+        let die_d = get_uniform_die(Digit::MIN, Digit::MAX);
+        let die_dd = get_uniform_die(Digit::MAX as DDigit + 1, DDigit::MAX);
+
+        for _ in 0..i16::MAX {
+            let digit = die_d.sample(&mut rng);
+            let digit_arbi = Arbi::from(digit);
+            assert_eq!(
+                digit_arbi.trailing_ones(),
+                digit.trailing_ones() as u128
+            );
+
+            let ddigit = die_dd.sample(&mut rng);
+            let ddigit_arbi = Arbi::from(ddigit);
+            assert_eq!(
+                ddigit_arbi.trailing_ones(),
+                ddigit.trailing_ones() as u128
+            );
+        }
+    }
+
+    #[test]
+    fn boundaries() {
+        let zero = Arbi::zero();
+        assert_eq!(zero.trailing_ones(), 0_u32.trailing_ones() as u128);
+
+        let mut a = Arbi::from(Digit::MAX - 1);
+        assert_eq!(a.trailing_ones(), (Digit::MAX - 1).trailing_ones() as u128);
+
+        a.assign(Digit::MAX);
+        assert_eq!(a.trailing_ones(), Digit::MAX.trailing_ones() as u128);
+
+        a.incr();
+        assert_eq!(
+            a.trailing_ones(),
+            (Digit::MAX as DDigit + 1).trailing_ones() as u128
+        );
+
+        a.assign(DDigit::MAX - 1);
+        assert_eq!(
+            a.trailing_ones(),
+            (DDigit::MAX - 1).trailing_ones() as u128
+        );
+
+        a.assign(DDigit::MAX);
+        assert_eq!(a.trailing_ones(), DDigit::MAX.trailing_ones() as u128);
+
+        a.assign(DDigit::MAX as QDigit + 1);
+        assert_eq!(
+            a.trailing_ones(),
+            (DDigit::MAX as QDigit + 1).trailing_ones() as u128
+        );
+    }
+}

--- a/arbi/src/lib.rs
+++ b/arbi/src/lib.rs
@@ -21,6 +21,7 @@ pub mod base;
 mod bit_length;
 mod bits;
 mod bitwise;
+mod builtin_int_methods;
 mod comparisons;
 mod comparisons_double;
 mod comparisons_integral;


### PR DESCRIPTION
Adds implementations for `Arbi` for a few methods defined on primitive integer types in Rust. This PR implements the following:

- `count_ones()`
- `leading_ones()`
- `trailing_ones()`
- `swap_bytes()`
- `reverse_bits()`

More implementations to come.