### PR TITLE
Bump version to 0.2.2

### DIFF
--- a/arbi/Cargo.toml
+++ b/arbi/Cargo.toml
@@ -18,7 +18,7 @@ license = "Apache-2.0 OR MIT"
 name = "arbi"
 readme = "README.md"
 repository = "https://github.com/OTheDev/arbi"
-version = "0.2.1"
+version = "0.2.2"
 
 [dependencies]
 


### PR DESCRIPTION
* Added `to_be_bytes()`, `to_le_bytes()`, and signed versions (#14)
* Added `from_be_bytes()`, `from_le_bytes()`, and signed versions (#13)