### PR TITLE
Distinguish between owned, mut, and ref versions in `builtin_int_methods`

### DIFF
--- a/arbi/src/builtin_int_methods/abs.rs
+++ b/arbi/src/builtin_int_methods/abs.rs
@@ -30,6 +30,25 @@ impl Arbi {
     /// # Examples
     /// ```
     /// use arbi::Arbi;
+    /// let mut neg = Arbi::from(-123456789);
+    /// neg.abs_mut();
+    /// assert_eq!(neg, 123456789);
+    /// ```
+    ///
+    /// # Complexity
+    /// \\( O(1) \\)
+    #[inline(always)]
+    pub fn abs_mut(&mut self) {
+        if self.neg {
+            self.neg = false;
+        }
+    }
+
+    /// Computes the absolute value of `self`.
+    ///
+    /// # Examples
+    /// ```
+    /// use arbi::Arbi;
     /// let neg = Arbi::from(-123456789);
     /// assert_eq!(neg.abs_ref(), 123456789);
     /// ```
@@ -43,25 +62,6 @@ impl Arbi {
             ret.negate();
         }
         ret
-    }
-
-    /// Computes the absolute value of `self`.
-    ///
-    /// # Examples
-    /// ```
-    /// use arbi::Arbi;
-    /// let mut neg = Arbi::from(-123456789);
-    /// neg.abs_mut();
-    /// assert_eq!(neg, 123456789);
-    /// ```
-    ///
-    /// # Complexity
-    /// \\( O(1) \\)
-    #[inline(always)]
-    pub fn abs_mut(&mut self) {
-        if self.neg {
-            self.neg = false;
-        }
     }
 }
 

--- a/arbi/src/builtin_int_methods/abs.rs
+++ b/arbi/src/builtin_int_methods/abs.rs
@@ -9,14 +9,14 @@ impl Arbi {
     /// Computes the absolute value of `self`.
     ///
     /// For in-place absolute value (\\( O(1) \\) operation), see
-    /// [`Arbi::abs_mut()`].
+    /// [`Arbi::abs_mut()`]. [`Arbi::abs()`] is also \\( O(1) \\).
     ///
     /// # Examples
     /// ```
     /// use arbi::Arbi;
     ///
     /// let neg = Arbi::from(-123456789);
-    /// let pos = neg.abs();
+    /// let pos = neg.abs_ref();
     ///
     /// assert_eq!(pos, 123456789);
     /// ```
@@ -24,7 +24,7 @@ impl Arbi {
     /// # Complexity
     /// \\( O(n) \\)
     #[inline(always)]
-    pub fn abs(&self) -> Arbi {
+    pub fn abs_ref(&self) -> Arbi {
         let mut ret = self.clone();
         if self.neg {
             ret.negate();
@@ -51,6 +51,31 @@ impl Arbi {
         if self.neg {
             self.neg = false;
         }
+    }
+
+    /// Computes the absolute value of `self`.
+    ///
+    /// For in-place absolute value (\\( O(1) \\) operation), see
+    /// [`Arbi::abs_mut()`].
+    ///
+    /// # Examples
+    /// ```
+    /// use arbi::Arbi;
+    ///
+    /// let neg = Arbi::from(-123456789);
+    /// let pos = neg.abs();
+    ///
+    /// assert_eq!(pos, 123456789);
+    /// ```
+    ///
+    /// # Complexity
+    /// \\( O(1) \\)
+    #[inline(always)]
+    pub fn abs(mut self) -> Arbi {
+        if self.neg {
+            self.negate();
+        }
+        self
     }
 }
 

--- a/arbi/src/builtin_int_methods/abs.rs
+++ b/arbi/src/builtin_int_methods/abs.rs
@@ -8,17 +8,30 @@ use crate::Arbi;
 impl Arbi {
     /// Computes the absolute value of `self`.
     ///
-    /// For in-place absolute value (\\( O(1) \\) operation), see
-    /// [`Arbi::abs_mut()`]. [`Arbi::abs()`] is also \\( O(1) \\).
+    /// # Examples
+    /// ```
+    /// use arbi::Arbi;
+    /// let neg = Arbi::from(-123456789);
+    /// assert_eq!(neg.abs(), 123456789);
+    /// ```
+    ///
+    /// # Complexity
+    /// \\( O(1) \\)
+    #[inline(always)]
+    pub fn abs(mut self) -> Arbi {
+        if self.neg {
+            self.negate();
+        }
+        self
+    }
+
+    /// Computes the absolute value of `self`.
     ///
     /// # Examples
     /// ```
     /// use arbi::Arbi;
-    ///
     /// let neg = Arbi::from(-123456789);
-    /// let pos = neg.abs_ref();
-    ///
-    /// assert_eq!(pos, 123456789);
+    /// assert_eq!(neg.abs_ref(), 123456789);
     /// ```
     ///
     /// # Complexity
@@ -32,15 +45,13 @@ impl Arbi {
         ret
     }
 
-    /// Computes the absolute value of `self`, in-place.
+    /// Computes the absolute value of `self`.
     ///
     /// # Examples
     /// ```
     /// use arbi::Arbi;
-    ///
     /// let mut neg = Arbi::from(-123456789);
     /// neg.abs_mut();
-    ///
     /// assert_eq!(neg, 123456789);
     /// ```
     ///
@@ -51,31 +62,6 @@ impl Arbi {
         if self.neg {
             self.neg = false;
         }
-    }
-
-    /// Computes the absolute value of `self`.
-    ///
-    /// For in-place absolute value (\\( O(1) \\) operation), see
-    /// [`Arbi::abs_mut()`].
-    ///
-    /// # Examples
-    /// ```
-    /// use arbi::Arbi;
-    ///
-    /// let neg = Arbi::from(-123456789);
-    /// let pos = neg.abs();
-    ///
-    /// assert_eq!(pos, 123456789);
-    /// ```
-    ///
-    /// # Complexity
-    /// \\( O(1) \\)
-    #[inline(always)]
-    pub fn abs(mut self) -> Arbi {
-        if self.neg {
-            self.negate();
-        }
-        self
     }
 }
 
@@ -108,5 +94,17 @@ mod tests {
         let mut zer = Arbi::zero();
         zer.abs_mut();
         assert_eq!(zer, 0);
+    }
+
+    #[test]
+    fn test_abs_ref() {
+        let pos = Arbi::from(123);
+        assert_eq!(pos.abs_ref(), 123);
+
+        let neg = Arbi::from(-123);
+        assert_eq!(neg.abs_ref(), 123);
+
+        let zer = Arbi::zero();
+        assert_eq!(zer.abs_ref(), 0);
     }
 }

--- a/arbi/src/builtin_int_methods/abs_diff.rs
+++ b/arbi/src/builtin_int_methods/abs_diff.rs
@@ -6,33 +6,29 @@ SPDX-License-Identifier: Apache-2.0 OR MIT
 use crate::Arbi;
 
 impl Arbi {
-    /// Computes the absolute difference between `self` and other.
+    /// Computes the absolute difference between `self` and `other`.
     ///
     /// # Examples
     /// ```
     /// use arbi::Arbi;
-    /// assert_eq!(Arbi::from(8000).abs_diff_ref(&Arbi::from(10000)), 2000);
-    /// assert_eq!(Arbi::from(-10000).abs_diff_ref(&Arbi::from(8000)), 18000);
-    /// assert_eq!(Arbi::from(-10000).abs_diff_ref(&Arbi::from(-11000)), 1000);
+    /// assert_eq!(Arbi::from(8000).abs_diff(Arbi::from(10000)), 2000);
+    /// assert_eq!(Arbi::from(-10000).abs_diff(Arbi::from(8000)), 18000);
+    /// assert_eq!(Arbi::from(-10000).abs_diff(Arbi::from(-11000)), 1000);
     /// ```
     ///
     /// # Complexity
     /// \\( O(n) \\)
-    pub fn abs_diff_ref(&self, other: &Self) -> Self {
-        let clone: Arbi;
-        let mut ret: Arbi;
-        if self.size() > other.size() {
-            clone = self.clone();
-            ret = clone - other;
+    pub fn abs_diff(self, other: Self) -> Self {
+        let mut ret = if self.size() > other.size() {
+            self - other
         } else {
-            clone = other.clone();
-            ret = clone - self;
-        }
+            other - self
+        };
         ret.abs_mut();
         ret
     }
 
-    /// Computes the absolute difference between `self` and other.
+    /// Computes the absolute difference between `self` and `other`.
     ///
     /// # Examples
     /// ```
@@ -62,24 +58,28 @@ impl Arbi {
         self.abs_mut();
     }
 
-    /// Computes the absolute difference between `self` and other.
+    /// Computes the absolute difference between `self` and `other`.
     ///
     /// # Examples
     /// ```
     /// use arbi::Arbi;
-    /// assert_eq!(Arbi::from(8000).abs_diff(Arbi::from(10000)), 2000);
-    /// assert_eq!(Arbi::from(-10000).abs_diff(Arbi::from(8000)), 18000);
-    /// assert_eq!(Arbi::from(-10000).abs_diff(Arbi::from(-11000)), 1000);
+    /// assert_eq!(Arbi::from(8000).abs_diff_ref(&Arbi::from(10000)), 2000);
+    /// assert_eq!(Arbi::from(-10000).abs_diff_ref(&Arbi::from(8000)), 18000);
+    /// assert_eq!(Arbi::from(-10000).abs_diff_ref(&Arbi::from(-11000)), 1000);
     /// ```
     ///
     /// # Complexity
     /// \\( O(n) \\)
-    pub fn abs_diff(self, other: Self) -> Self {
-        let mut ret = if self.size() > other.size() {
-            self - other
+    pub fn abs_diff_ref(&self, other: &Self) -> Self {
+        let clone: Arbi;
+        let mut ret: Arbi;
+        if self.size() > other.size() {
+            clone = self.clone();
+            ret = clone - other;
         } else {
-            other - self
-        };
+            clone = other.clone();
+            ret = clone - self;
+        }
         ret.abs_mut();
         ret
     }

--- a/arbi/src/builtin_int_methods/abs_diff.rs
+++ b/arbi/src/builtin_int_methods/abs_diff.rs
@@ -11,15 +11,14 @@ impl Arbi {
     /// # Examples
     /// ```
     /// use arbi::Arbi;
-    ///
-    /// assert_eq!(Arbi::from(8000).abs_diff(&Arbi::from(10000)), 2000);
-    /// assert_eq!(Arbi::from(-10000).abs_diff(&Arbi::from(8000)), 18000);
-    /// assert_eq!(Arbi::from(-10000).abs_diff(&Arbi::from(-11000)), 1000);
+    /// assert_eq!(Arbi::from(8000).abs_diff_ref(&Arbi::from(10000)), 2000);
+    /// assert_eq!(Arbi::from(-10000).abs_diff_ref(&Arbi::from(8000)), 18000);
+    /// assert_eq!(Arbi::from(-10000).abs_diff_ref(&Arbi::from(-11000)), 1000);
     /// ```
     ///
     /// # Complexity
     /// \\( O(n) \\)
-    pub fn abs_diff(&self, other: &Self) -> Self {
+    pub fn abs_diff_ref(&self, other: &Self) -> Self {
         let clone: Arbi;
         let mut ret: Arbi;
         if self.size() > other.size() {
@@ -33,7 +32,7 @@ impl Arbi {
         ret
     }
 
-    /// Computes the absolute difference between `self` and other, in-place.
+    /// Computes the absolute difference between `self` and other.
     ///
     /// # Examples
     /// ```
@@ -61,5 +60,27 @@ impl Arbi {
     pub fn abs_diff_mut(&mut self, other: &Self) {
         *self -= other;
         self.abs_mut();
+    }
+
+    /// Computes the absolute difference between `self` and other.
+    ///
+    /// # Examples
+    /// ```
+    /// use arbi::Arbi;
+    /// assert_eq!(Arbi::from(8000).abs_diff(Arbi::from(10000)), 2000);
+    /// assert_eq!(Arbi::from(-10000).abs_diff(Arbi::from(8000)), 18000);
+    /// assert_eq!(Arbi::from(-10000).abs_diff(Arbi::from(-11000)), 1000);
+    /// ```
+    ///
+    /// # Complexity
+    /// \\( O(n) \\)
+    pub fn abs_diff(self, other: Self) -> Self {
+        let mut ret = if self.size() > other.size() {
+            self - other
+        } else {
+            other - self
+        };
+        ret.abs_mut();
+        ret
     }
 }

--- a/arbi/src/builtin_int_methods/euclid_div_and_rem.rs
+++ b/arbi/src/builtin_int_methods/euclid_div_and_rem.rs
@@ -9,7 +9,7 @@ impl Arbi {
     /// Calculates the quotient of Euclidean division of `self` by `rhs`.
     ///
     /// # See also
-    /// - [`div_euclid_ref()`](https://doc.rust-lang.org/std/primitive.i64.html#method.div_euclid_ref)
+    /// - [`div_euclid()`](https://doc.rust-lang.org/std/primitive.i64.html#method.div_euclid)
     ///     for built-in integer types.
     /// - [`Arbi::divrem_euclid_ref()`].
     ///
@@ -55,7 +55,7 @@ impl Arbi {
     /// Calculates the least nonnegative remainder of `self (mod rhs)`.
     ///
     /// # See also
-    /// - [`rem_euclid_ref()`](https://doc.rust-lang.org/std/primitive.i64.html#method.rem_euclid_ref)
+    /// - [`rem_euclid()`](https://doc.rust-lang.org/std/primitive.i64.html#method.rem_euclid)
     ///     for built-in integer types.
     /// - [`Arbi::divrem_euclid_ref()`].
     ///
@@ -102,7 +102,8 @@ impl Arbi {
     // allocations. Also, see if we can do all of this in the same pass as the
     // main algo.
 
-    /// Same as `(self.div_euclid_ref(rhs), self.rem_euclid_ref(rhs))`, but in one pass.
+    /// Same as `(self.div_euclid_ref(rhs), self.rem_euclid_ref(rhs))`, but in
+    /// one pass.
     ///
     /// # Panics
     /// This function will panic if `rhs` is `0`.

--- a/arbi/src/builtin_int_methods/euclid_div_and_rem.rs
+++ b/arbi/src/builtin_int_methods/euclid_div_and_rem.rs
@@ -9,9 +9,9 @@ impl Arbi {
     /// Calculates the quotient of Euclidean division of `self` by `rhs`.
     ///
     /// # See also
-    /// - [`div_euclid()`](https://doc.rust-lang.org/std/primitive.i64.html#method.div_euclid)
+    /// - [`div_euclid_ref()`](https://doc.rust-lang.org/std/primitive.i64.html#method.div_euclid_ref)
     ///     for built-in integer types.
-    /// - [`Arbi::divrem_euclid()`].
+    /// - [`Arbi::divrem_euclid_ref()`].
     ///
     /// # Panics
     /// This function will panic if `rhs` is `0`.
@@ -23,17 +23,17 @@ impl Arbi {
     /// let mut a = Arbi::from(9);
     /// let mut b = Arbi::from(5);
     ///
-    /// assert_eq!(a.div_euclid(&b), 1);
+    /// assert_eq!(a.div_euclid_ref(&b), 1);
     ///
     /// b.negate();
-    /// assert_eq!(a.div_euclid(&b), -1);
+    /// assert_eq!(a.div_euclid_ref(&b), -1);
     ///
     /// a.negate();
     /// b.negate();
-    /// assert_eq!(a.div_euclid(&b), -2);
+    /// assert_eq!(a.div_euclid_ref(&b), -2);
     ///
     /// b.negate();
-    /// assert_eq!(a.div_euclid(&b), 2);
+    /// assert_eq!(a.div_euclid_ref(&b), 2);
     /// ```
     ///
     /// Panics if `rhs` is zero:
@@ -42,22 +42,22 @@ impl Arbi {
     ///
     /// let num = Arbi::from(9);
     /// let den = Arbi::zero();
-    /// num.div_euclid(&den);
+    /// num.div_euclid_ref(&den);
     /// ```
     ///
     /// # Complexity
     /// \\( O(m \cdot n) \\)
-    pub fn div_euclid(&self, rhs: &Self) -> Arbi {
-        let (quot, _) = self.divrem_euclid(rhs);
+    pub fn div_euclid_ref(&self, rhs: &Self) -> Arbi {
+        let (quot, _) = self.divrem_euclid_ref(rhs);
         quot
     }
 
     /// Calculates the least nonnegative remainder of `self (mod rhs)`.
     ///
     /// # See also
-    /// - [`rem_euclid()`](https://doc.rust-lang.org/std/primitive.i64.html#method.rem_euclid)
+    /// - [`rem_euclid_ref()`](https://doc.rust-lang.org/std/primitive.i64.html#method.rem_euclid_ref)
     ///     for built-in integer types.
-    /// - [`Arbi::divrem_euclid()`].
+    /// - [`Arbi::divrem_euclid_ref()`].
     ///
     /// # Panics
     /// This function will panic if `rhs` is `0`.
@@ -69,17 +69,17 @@ impl Arbi {
     /// let mut a = Arbi::from(9);
     /// let mut b = Arbi::from(5);
     ///
-    /// assert_eq!(a.rem_euclid(&b), 4);
+    /// assert_eq!(a.rem_euclid_ref(&b), 4);
     ///
     /// b.negate();
-    /// assert_eq!(a.rem_euclid(&b), 4);
+    /// assert_eq!(a.rem_euclid_ref(&b), 4);
     ///
     /// a.negate();
     /// b.negate();
-    /// assert_eq!(a.rem_euclid(&b), 1);
+    /// assert_eq!(a.rem_euclid_ref(&b), 1);
     ///
     /// b.negate();
-    /// assert_eq!(a.rem_euclid(&b), 1);
+    /// assert_eq!(a.rem_euclid_ref(&b), 1);
     /// ```
     ///
     /// Panics if `rhs` is zero:
@@ -88,13 +88,13 @@ impl Arbi {
     ///
     /// let num = Arbi::from(9);
     /// let den = Arbi::zero();
-    /// num.rem_euclid(&den);
+    /// num.rem_euclid_ref(&den);
     /// ```
     ///
     /// # Complexity
     /// \\( O(m \cdot n) \\)
-    pub fn rem_euclid(&self, rhs: &Self) -> Arbi {
-        let (_, rem) = self.divrem_euclid(rhs);
+    pub fn rem_euclid_ref(&self, rhs: &Self) -> Arbi {
+        let (_, rem) = self.divrem_euclid_ref(rhs);
         rem
     }
 
@@ -102,7 +102,7 @@ impl Arbi {
     // allocations. Also, see if we can do all of this in the same pass as the
     // main algo.
 
-    /// Same as `(self.div_euclid(rhs), self.rem_euclid(rhs))`, but in one pass.
+    /// Same as `(self.div_euclid_ref(rhs), self.rem_euclid_ref(rhs))`, but in one pass.
     ///
     /// # Panics
     /// This function will panic if `rhs` is `0`.
@@ -114,20 +114,20 @@ impl Arbi {
     /// let mut a = Arbi::from(9);
     /// let mut b = Arbi::from(5);
     ///
-    /// let (quo, rem) = a.divrem_euclid(&b);
+    /// let (quo, rem) = a.divrem_euclid_ref(&b);
     /// assert!(quo == 1 && rem == 4);
     ///
     /// b.negate();
-    /// let (quo, rem) = a.divrem_euclid(&b);
+    /// let (quo, rem) = a.divrem_euclid_ref(&b);
     /// assert!(quo == -1 && rem == 4);
     ///
     /// a.negate();
     /// b.negate();
-    /// let (quo, rem) = a.divrem_euclid(&b);
+    /// let (quo, rem) = a.divrem_euclid_ref(&b);
     /// assert!(quo == -2 && rem == 1);
     ///
     /// b.negate();
-    /// let (quo, rem) = a.divrem_euclid(&b);
+    /// let (quo, rem) = a.divrem_euclid_ref(&b);
     /// assert!(quo == 2 && rem == 1);
     /// ```
     ///
@@ -137,12 +137,12 @@ impl Arbi {
     ///
     /// let num = Arbi::from(9);
     /// let den = Arbi::zero();
-    /// num.divrem_euclid(&den);
+    /// num.divrem_euclid_ref(&den);
     /// ```
     ///
     /// # Complexity
     /// \\( O(m \cdot n) \\)
-    pub fn divrem_euclid(&self, rhs: &Self) -> (Arbi, Arbi) {
+    pub fn divrem_euclid_ref(&self, rhs: &Self) -> (Arbi, Arbi) {
         let (mut quot, mut rem) = self.div(rhs);
         if rem.is_negative() {
             if rhs.is_negative() {
@@ -191,7 +191,7 @@ mod tests {
                     continue;
                 }
 
-                let (quot, rem) = a.divrem_euclid(&b);
+                let (quot, rem) = a.divrem_euclid_ref(&b);
 
                 assert_eq!(
                     quot,

--- a/arbi/src/builtin_int_methods/ilog.rs
+++ b/arbi/src/builtin_int_methods/ilog.rs
@@ -15,7 +15,6 @@ impl Arbi {
     /// # Examples
     /// ```
     /// use arbi::Arbi;
-    ///
     /// let a = Arbi::from(10);
     /// assert_eq!(a.ilog(8), 1);
     /// ```
@@ -23,14 +22,12 @@ impl Arbi {
     /// Nonpositive values panic:
     /// ```should_panic
     /// use arbi::Arbi;
-    ///
     /// let zero = Arbi::zero();
     /// zero.ilog(8);
     /// ```
     ///
     /// ```should_panic
     /// use arbi::Arbi;
-    ///
     /// let minus_one = Arbi::from(-1);
     /// minus_one.ilog(8);
     /// ```
@@ -38,18 +35,35 @@ impl Arbi {
     /// A base less than 2 causes a panic
     /// ```should_panic
     /// use arbi::Arbi;
-    ///
     /// let a = Arbi::from(4);
     /// a.ilog(1);
     /// ```
-    pub fn ilog(&self, base: u32) -> BitCount {
-        if self <= 0 {
-            panic!("self must be positive: {}", self);
+    pub fn ilog(self, base: u32) -> BitCount {
+        Self::check_ilog_args(&self, base);
+        self.size_base(base) - 1
+    }
+
+    /// See [`Arbi::ilog()`].
+    pub fn ilog_ref(&self, base: u32) -> BitCount {
+        Self::check_ilog_args(self, base);
+        self.size_base_ref(base) - 1
+    }
+
+    /// See [`Arbi::ilog_mut()`].
+    pub fn ilog_mut(&mut self, base: u32) -> BitCount {
+        Self::check_ilog_args(self, base);
+        let ret = self.size_base_mut(base) - 1;
+        self.decr();
+        ret
+    }
+
+    fn check_ilog_args(x: &Self, base: u32) {
+        if x <= 0 {
+            panic!("self must be positive: {}", x);
         }
         if base < 2 {
             panic!("base must be greater than or equal to 2: {}", base);
         }
-        self.size_base(base) - 1
     }
 }
 
@@ -62,21 +76,21 @@ mod tests {
     fn test_digit_boundaries() {
         for base in 2u32..=36u32 {
             let a = Arbi::from(Digit::MAX);
-            assert_eq!(a.ilog(base), Digit::MAX.ilog(base) as BitCount);
+            assert_eq!(a.ilog_ref(base), Digit::MAX.ilog(base) as BitCount);
             let a = Arbi::from(Digit::MAX as DDigit + 1);
             assert_eq!(
-                a.ilog(base),
+                a.ilog_ref(base),
                 (Digit::MAX as DDigit + 1).ilog(base as DDigit) as BitCount
             );
 
             let a = Arbi::from(DDigit::MAX);
             assert_eq!(
-                a.ilog(base),
+                a.ilog_ref(base),
                 DDigit::MAX.ilog(base as DDigit) as BitCount
             );
             let a = Arbi::from(DDigit::MAX as QDigit + 1);
             assert_eq!(
-                a.ilog(base),
+                a.ilog_ref(base),
                 (DDigit::MAX as QDigit + 1).ilog(base as QDigit) as BitCount
             );
         }
@@ -86,21 +100,21 @@ mod tests {
     #[should_panic = "self must be positive: 0"]
     fn test_zero() {
         let a = Arbi::zero();
-        a.ilog(8);
+        a.ilog_ref(8);
     }
 
     #[test]
     #[should_panic = "self must be positive: -4"]
     fn test_is_power_of_two_negative() {
         let a = Arbi::from(-4);
-        a.ilog(8);
+        a.ilog_ref(8);
     }
 
     #[test]
     #[should_panic = "base must be greater than or equal to 2: 0"]
     fn test_invalid_base() {
         let a = Arbi::from(4);
-        a.ilog(0);
+        a.ilog_ref(0);
     }
 
     #[test]
@@ -118,15 +132,21 @@ mod tests {
                     continue;
                 }
                 let a = Arbi::from(r);
-                assert_eq!(a.ilog(base), r.ilog(base) as BitCount);
+                assert_eq!(a.ilog_ref(base), r.ilog(base) as BitCount);
 
                 let r = die_ddigit.sample(&mut rng);
                 let a = Arbi::from(r);
-                assert_eq!(a.ilog(base), r.ilog(base as DDigit) as BitCount);
+                assert_eq!(
+                    a.ilog_ref(base),
+                    r.ilog(base as DDigit) as BitCount
+                );
 
                 let r = die_qdigit.sample(&mut rng);
                 let a = Arbi::from(r);
-                assert_eq!(a.ilog(base), r.ilog(base as QDigit) as BitCount);
+                assert_eq!(
+                    a.ilog_ref(base),
+                    r.ilog(base as QDigit) as BitCount
+                );
             }
         }
     }

--- a/arbi/src/builtin_int_methods/ilog.rs
+++ b/arbi/src/builtin_int_methods/ilog.rs
@@ -43,18 +43,79 @@ impl Arbi {
         self.size_base(base) - 1
     }
 
-    /// See [`Arbi::ilog()`].
-    pub fn ilog_ref(&self, base: u32) -> BitCount {
-        Self::check_ilog_args(self, base);
-        self.size_base_ref(base) - 1
-    }
-
-    /// See [`Arbi::ilog_mut()`].
+    /// Returns the base-`base` logarithm of the number, rounded down.
+    ///
+    /// # Panics
+    /// This function will panic if `self` is less than or equal to zero, or if
+    /// `base` is less than 2.
+    ///
+    /// # Examples
+    /// ```
+    /// use arbi::Arbi;
+    /// let mut a = Arbi::from(10);
+    /// a.ilog_mut(8);
+    /// assert_eq!(a, 1);
+    /// ```
+    ///
+    /// Nonpositive values panic:
+    /// ```should_panic
+    /// use arbi::Arbi;
+    /// let mut zero = Arbi::zero();
+    /// zero.ilog_mut(8);
+    /// ```
+    /// ```should_panic
+    /// use arbi::Arbi;
+    /// let mut minus_one = Arbi::from(-1);
+    /// minus_one.ilog_mut(8);
+    /// ```
+    ///
+    /// A base less than 2 causes a panic
+    /// ```should_panic
+    /// use arbi::Arbi;
+    /// let mut a = Arbi::from(4);
+    /// a.ilog_mut(1);
+    /// ```
     pub fn ilog_mut(&mut self, base: u32) -> BitCount {
         Self::check_ilog_args(self, base);
         let ret = self.size_base_mut(base) - 1;
         self.decr();
         ret
+    }
+
+    /// Returns the base-`base` logarithm of the number, rounded down.
+    ///
+    /// # Panics
+    /// This function will panic if `self` is less than or equal to zero, or if
+    /// `base` is less than 2.
+    ///
+    /// # Examples
+    /// ```
+    /// use arbi::Arbi;
+    /// let a = Arbi::from(10);
+    /// assert_eq!(a.ilog_ref(8), 1);
+    /// ```
+    ///
+    /// Nonpositive values panic:
+    /// ```should_panic
+    /// use arbi::Arbi;
+    /// let zero = Arbi::zero();
+    /// zero.ilog_ref(8);
+    /// ```
+    /// ```should_panic
+    /// use arbi::Arbi;
+    /// let minus_one = Arbi::from(-1);
+    /// minus_one.ilog_ref(8);
+    /// ```
+    ///
+    /// A base less than 2 causes a panic
+    /// ```should_panic
+    /// use arbi::Arbi;
+    /// let a = Arbi::from(4);
+    /// a.ilog_ref(1);
+    /// ```
+    pub fn ilog_ref(&self, base: u32) -> BitCount {
+        Self::check_ilog_args(self, base);
+        self.size_base_ref(base) - 1
     }
 
     fn check_ilog_args(x: &Self, base: u32) {

--- a/arbi/src/builtin_int_methods/ilog10.rs
+++ b/arbi/src/builtin_int_methods/ilog10.rs
@@ -14,7 +14,6 @@ impl Arbi {
     /// # Examples
     /// ```
     /// use arbi::Arbi;
-    ///
     /// let a = Arbi::from(10);
     /// assert_eq!(a.ilog10(), 1);
     /// ```
@@ -22,22 +21,70 @@ impl Arbi {
     /// Nonpositive values panic:
     /// ```should_panic
     /// use arbi::Arbi;
-    ///
     /// let zero = Arbi::zero();
     /// zero.ilog10();
     /// ```
     ///
     /// ```should_panic
     /// use arbi::Arbi;
-    ///
     /// let minus_one = Arbi::from(-1);
     /// minus_one.ilog10();
     /// ```
-    pub fn ilog10(&self) -> BitCount {
-        if self <= 0 {
-            panic!("self must be positive: {}", self);
-        }
-        self.size_base(10) - 1
+    pub fn ilog10(self) -> BitCount {
+        self.ilog(10)
+    }
+
+    /// See [`Arbi::ilog10()`].
+    ///
+    /// The value of `self` will compare equal to the return value.
+    ///
+    /// # Examples
+    /// ```
+    /// use arbi::Arbi;
+    /// let mut a = Arbi::from(10);
+    /// assert_eq!(a.ilog10_mut(), 1);
+    /// assert_eq!(a, 1);
+    /// ```
+    ///
+    /// Nonpositive values panic:
+    /// ```should_panic
+    /// use arbi::Arbi;
+    /// let mut zero = Arbi::zero();
+    /// zero.ilog10_mut();
+    /// ```
+    ///
+    /// ```should_panic
+    /// use arbi::Arbi;
+    /// let mut minus_one = Arbi::from(-1);
+    /// minus_one.ilog10_mut();
+    /// ```
+    pub fn ilog10_mut(&mut self) -> BitCount {
+        self.ilog_mut(10)
+    }
+
+    /// See [`Arbi::ilog10()`].
+    ///
+    /// # Examples
+    /// ```
+    /// use arbi::Arbi;
+    /// let a = Arbi::from(10);
+    /// assert_eq!(a.ilog10_ref(), 1);
+    /// ```
+    ///
+    /// Nonpositive values panic:
+    /// ```should_panic
+    /// use arbi::Arbi;
+    /// let zero = Arbi::zero();
+    /// zero.ilog10_ref();
+    /// ```
+    ///
+    /// ```should_panic
+    /// use arbi::Arbi;
+    /// let minus_one = Arbi::from(-1);
+    /// minus_one.ilog10_ref();
+    /// ```
+    pub fn ilog10_ref(&self) -> BitCount {
+        self.ilog_ref(10)
     }
 }
 

--- a/arbi/src/builtin_int_methods/ilog10.rs
+++ b/arbi/src/builtin_int_methods/ilog10.rs
@@ -34,9 +34,12 @@ impl Arbi {
         self.ilog(10)
     }
 
-    /// See [`Arbi::ilog10()`].
+    /// Returns the base 10 logarithm of the number, rounded down.
     ///
     /// The value of `self` will compare equal to the return value.
+    ///
+    /// # Panics
+    /// This function will panic if `self` is less than or equal to zero.
     ///
     /// # Examples
     /// ```
@@ -62,7 +65,10 @@ impl Arbi {
         self.ilog_mut(10)
     }
 
-    /// See [`Arbi::ilog10()`].
+    /// Returns the base 10 logarithm of the number, rounded down.
+    ///
+    /// # Panics
+    /// This function will panic if `self` is less than or equal to zero.
     ///
     /// # Examples
     /// ```

--- a/arbi/src/builtin_int_methods/reverse_bits.rs
+++ b/arbi/src/builtin_int_methods/reverse_bits.rs
@@ -16,16 +16,27 @@ impl Arbi {
     /// # Examples
     /// ```
     /// use arbi::Arbi;
-    ///
     /// let a = Arbi::from(0x12345678_u32);
-    /// let b = a.reverse_bits();
-    ///
-    /// assert_eq!(b, 0x12345678_u32.reverse_bits());
+    /// assert_eq!(a.reverse_bits(), 0x12345678_u32.reverse_bits());
     /// ```
     ///
-    /// ## Complexity
+    /// # Complexity
     /// \\( O(n) \\)
     pub fn reverse_bits(mut self) -> Self {
+        self.reverse_bits_mut();
+        self
+    }
+
+    /// See [`Arbi::reverse_bits()`].
+    ///
+    /// # Examples
+    /// ```
+    /// use arbi::Arbi;
+    /// let mut a = Arbi::from(0x12345678_u32);
+    /// a.reverse_bits_mut();
+    /// assert_eq!(a, 0x12345678_u32.reverse_bits());
+    /// ```
+    pub fn reverse_bits_mut(&mut self) {
         let len = self.vec.len();
         for i in 0..(len / 2) {
             self.vec[i] = self.vec[i].reverse_bits();
@@ -36,7 +47,20 @@ impl Arbi {
             self.vec[len / 2] = self.vec[len / 2].reverse_bits();
         }
         self.trim();
-        self
+    }
+
+    /// See [`Arbi::reverse_bits()`].
+    ///
+    /// # Examples
+    /// ```
+    /// use arbi::Arbi;
+    /// let a = Arbi::from(0x12345678_u32);
+    /// let b: Arbi = a.reverse_bits_ref();
+    /// assert_eq!(b, 0x12345678_u32.reverse_bits());
+    /// ```
+    pub fn reverse_bits_ref(&self) -> Self {
+        let ret = self.clone();
+        ret.reverse_bits()
     }
 }
 

--- a/arbi/src/builtin_int_methods/reverse_bits.rs
+++ b/arbi/src/builtin_int_methods/reverse_bits.rs
@@ -27,7 +27,12 @@ impl Arbi {
         self
     }
 
-    /// See [`Arbi::reverse_bits()`].
+    /// Reverses the order of bits in the absolute value of the integer.
+    ///
+    /// The least significant bit becomes the most significant bit, second least
+    /// significant bit becomes second most-significant bit, etc.
+    ///
+    /// The sign remains unchanged.
     ///
     /// # Examples
     /// ```
@@ -49,7 +54,12 @@ impl Arbi {
         self.trim();
     }
 
-    /// See [`Arbi::reverse_bits()`].
+    /// Reverses the order of bits in the absolute value of the integer.
+    ///
+    /// The least significant bit becomes the most significant bit, second least
+    /// significant bit becomes second most-significant bit, etc.
+    ///
+    /// The sign remains unchanged.
     ///
     /// # Examples
     /// ```

--- a/arbi/src/builtin_int_methods/swap_bytes.rs
+++ b/arbi/src/builtin_int_methods/swap_bytes.rs
@@ -13,16 +13,27 @@ impl Arbi {
     /// # Examples
     /// ```
     /// use arbi::Arbi;
-    ///
     /// let a = Arbi::from(0x12345678_u32);
-    /// let b = a.swap_bytes();
-    ///
-    /// assert_eq!(b, 0x78563412);
+    /// assert_eq!(a.swap_bytes(), 0x78563412);
     /// ```
     ///
     /// ## Complexity
     /// \\( O(n) \\)
     pub fn swap_bytes(mut self) -> Self {
+        self.swap_bytes_mut();
+        self
+    }
+
+    /// See [`Arbi::swap_bytes()`].
+    ///
+    /// # Examples
+    /// ```
+    /// use arbi::Arbi;
+    /// let mut a = Arbi::from(0x12345678_u32);
+    /// a.swap_bytes_mut();
+    /// assert_eq!(a, 0x78563412);
+    /// ```
+    pub fn swap_bytes_mut(&mut self) {
         let len = self.vec.len();
         for i in 0..(len / 2) {
             self.vec[i] = self.vec[i].swap_bytes();
@@ -33,7 +44,19 @@ impl Arbi {
             self.vec[len / 2] = self.vec[len / 2].swap_bytes();
         }
         self.trim();
-        self
+    }
+
+    /// See [`Arbi::swap_bytes()`].
+    ///
+    /// # Examples
+    /// ```
+    /// use arbi::Arbi;
+    /// let a = Arbi::from(0x12345678_u32);
+    /// assert_eq!(a.swap_bytes_ref(), 0x78563412);
+    /// ```
+    pub fn swap_bytes_ref(&self) -> Self {
+        let ret = self.clone();
+        ret.swap_bytes()
     }
 }
 

--- a/arbi/src/builtin_int_methods/swap_bytes.rs
+++ b/arbi/src/builtin_int_methods/swap_bytes.rs
@@ -24,7 +24,9 @@ impl Arbi {
         self
     }
 
-    /// See [`Arbi::swap_bytes()`].
+    /// Reverses the byte order of the absolute value of the integer.
+    ///
+    /// The sign remains unchanged.
     ///
     /// # Examples
     /// ```
@@ -46,7 +48,9 @@ impl Arbi {
         self.trim();
     }
 
-    /// See [`Arbi::swap_bytes()`].
+    /// Reverses the byte order of the absolute value of the integer.
+    ///
+    /// The sign remains unchanged.
     ///
     /// # Examples
     /// ```

--- a/arbi/src/size_base.rs
+++ b/arbi/src/size_base.rs
@@ -4,7 +4,8 @@ SPDX-License-Identifier: Apache-2.0 OR MIT
 */
 
 use crate::uints::UnsignedUtilities;
-use crate::{Arbi, BitCount};
+use crate::Assign;
+use crate::{Arbi, BitCount, Digit};
 
 impl Arbi {
     /// Return the number of base-`base` digits needed to represent the absolute
@@ -18,13 +19,10 @@ impl Arbi {
     /// # Examples
     /// ```
     /// use arbi::Arbi;
-    ///
     /// let zero = Arbi::zero();
     /// assert_eq!(zero.size_base(10), 0);
-    ///
     /// let one = Arbi::from(1);
     /// assert_eq!(one.size_base(10), 1);
-    ///
     /// let a = Arbi::from_str_radix("123456789", 10).unwrap();
     /// assert_eq!(a.size_base(10), 9);
     /// ```
@@ -36,27 +34,90 @@ impl Arbi {
     /// let a = Arbi::from(1234);
     /// a.size_base(1);
     /// ```
-    pub fn size_base(&self, base: u32) -> BitCount {
+    pub fn size_base(mut self, base: u32) -> BitCount {
+        self.size_base_mut(base)
+    }
+
+    /// See [`Arbi::size_base()`].
+    ///
+    /// The value of `self` will compare equal to the return value.
+    ///
+    /// # Examples
+    /// ```
+    /// use arbi::Arbi;
+    ///
+    /// let mut zero = Arbi::zero();
+    /// assert_eq!(zero.size_base_mut(10), 0);
+    /// assert_eq!(zero, 0);
+    ///
+    /// let mut one = Arbi::from(1);
+    /// assert_eq!(one.size_base_mut(10), 1);
+    /// assert_eq!(one, 1);
+    ///
+    /// let mut a = Arbi::from_str_radix("123456789", 10).unwrap();
+    /// assert_eq!(a.size_base_mut(10), 9);
+    /// assert_eq!(a, 9);
+    /// ```
+    pub fn size_base_mut(&mut self, base: u32) -> BitCount {
+        if let Some(v) = Self::check_args_size_base(self, base) {
+            self.assign(v);
+            v
+        } else {
+            let ret = self.size_radix_no_check(base);
+            self.assign(ret);
+            ret
+        }
+    }
+
+    /// See [`Arbi::size_base()`].
+    ///
+    /// # Examples
+    /// ```
+    /// use arbi::Arbi;
+    ///
+    /// let zero = Arbi::zero();
+    /// assert_eq!(zero.size_base_ref(10), 0);
+    ///
+    /// let one = Arbi::from(1);
+    /// assert_eq!(one.size_base_ref(10), 1);
+    ///
+    /// let a = Arbi::from_str_radix("123456789", 10).unwrap();
+    /// assert_eq!(a.size_base_ref(10), 9);
+    /// ```
+    pub fn size_base_ref(&self, base: u32) -> BitCount {
+        if let Some(v) = Self::check_args_size_base(self, base) {
+            return v;
+        }
+        // TODO: what can we achieve without memory allocation?
+        let mut clone = self.clone();
+        clone.size_radix_no_check(base)
+    }
+
+    pub(crate) fn size_radix_no_check(&mut self, base: u32) -> BitCount {
+        let mut count: BitCount = 0;
+        while self > 0 {
+            Self::div_algo_digit_inplace(self, base as Digit);
+            count += 1;
+        }
+        count
+    }
+
+    pub(crate) fn check_args_size_base(&self, base: u32) -> Option<BitCount> {
         if base <= 1 {
             panic!("base must be greater than 1: {}", base);
         }
         if self.is_zero() {
-            return 0;
+            return Some(0);
         }
         if base.is_power_of_two() {
             let bit_length = self.bit_length();
             let base_log2 = base.ilog2();
-            return BitCount::div_ceil_(bit_length, base_log2 as BitCount);
+            return Some(BitCount::div_ceil_(
+                bit_length,
+                base_log2 as BitCount,
+            ));
         }
-        use crate::Digit;
-        let mut count: BitCount = 0;
-        // TODO: what can we achieve without memory allocation?
-        let mut clone = self.clone();
-        while clone > 0 {
-            Self::div_algo_digit_inplace(&mut clone, base as Digit);
-            count += 1;
-        }
-        count
+        None
     }
 }
 
@@ -114,21 +175,21 @@ mod tests {
                 }
                 let a = Arbi::from(r);
                 assert_eq!(
-                    a.size_base(base),
+                    a.size_base_ref(base),
                     a.to_string_radix(base).len() as BitCount
                 );
 
                 let r = die_ddigit.sample(&mut rng);
                 let a = Arbi::from(r);
                 assert_eq!(
-                    a.size_base(base),
+                    a.size_base_ref(base),
                     a.to_string_radix(base).len() as BitCount
                 );
 
                 let r = die_qdigit.sample(&mut rng);
                 let a = Arbi::from(r);
                 assert_eq!(
-                    a.size_base(base),
+                    a.size_base_ref(base),
                     a.to_string_radix(base).len() as BitCount
                 );
             }

--- a/arbi/src/size_base.rs
+++ b/arbi/src/size_base.rs
@@ -30,7 +30,6 @@ impl Arbi {
     /// Panics on a base less than or equal to 1:
     /// ```should_panic
     /// use arbi::Arbi;
-    ///
     /// let a = Arbi::from(1234);
     /// a.size_base(1);
     /// ```
@@ -38,9 +37,15 @@ impl Arbi {
         self.size_base_mut(base)
     }
 
-    /// See [`Arbi::size_base()`].
+    /// Return the number of base-`base` digits needed to represent the absolute
+    /// value of this integer.
+    ///
+    /// Instance represents `0` if and only if `size_base_mut() == 0`.
     ///
     /// The value of `self` will compare equal to the return value.
+    ///
+    /// # Panics
+    /// This function will panic if `base` is less than or equal to 1.
     ///
     /// # Examples
     /// ```
@@ -58,6 +63,13 @@ impl Arbi {
     /// assert_eq!(a.size_base_mut(10), 9);
     /// assert_eq!(a, 9);
     /// ```
+    ///
+    /// Panics on a base less than or equal to 1:
+    /// ```should_panic
+    /// use arbi::Arbi;
+    /// let mut a = Arbi::from(1234);
+    /// a.size_base_mut(1);
+    /// ```
     pub fn size_base_mut(&mut self, base: u32) -> BitCount {
         if let Some(v) = Self::check_args_size_base(self, base) {
             self.assign(v);
@@ -69,7 +81,13 @@ impl Arbi {
         }
     }
 
-    /// See [`Arbi::size_base()`].
+    /// Return the number of base-`base` digits needed to represent the absolute
+    /// value of this integer.
+    ///
+    /// Instance represents `0` if and only if `size_base_ref() == 0`.
+    ///
+    /// # Panics
+    /// This function will panic if `base` is less than or equal to 1.
     ///
     /// # Examples
     /// ```
@@ -83,6 +101,13 @@ impl Arbi {
     ///
     /// let a = Arbi::from_str_radix("123456789", 10).unwrap();
     /// assert_eq!(a.size_base_ref(10), 9);
+    /// ```
+    ///
+    /// Panics on a base less than or equal to 1:
+    /// ```should_panic
+    /// use arbi::Arbi;
+    /// let a = Arbi::from(1234);
+    /// a.size_base_ref(1);
     /// ```
     pub fn size_base_ref(&self, base: u32) -> BitCount {
         if let Some(v) = Self::check_args_size_base(self, base) {

--- a/arbi/src/to_string.rs
+++ b/arbi/src/to_string.rs
@@ -77,7 +77,7 @@ impl Arbi {
             // TODO: find some quick upperbound.
             // let ilog2_base = base.ilog2();
             // (x.bit_length() - 1) / (ilog2_base as BitCount) + (1 as BitCount)
-            x.size_base(base as u32)
+            x.size_base_ref(base as u32)
         } else {
             // This is much more efficient than using size_base()
             crate::floor::floor(bitlen as f64 * LOG_BASE_2[base] + 1.0)
@@ -113,7 +113,7 @@ impl Arbi {
             Self::base_length(self, base) + if self.neg { 1 } else { 0 };
         let estimate: usize = if true_estimate > usize::MAX as BitCount {
             let exact =
-                self.size_base(base as u32) + if self.neg { 1 } else { 0 };
+                self.size_base_ref(base as u32) + if self.neg { 1 } else { 0 };
             assert!(exact > isize::MAX as BitCount);
             panic!(
                 "Base-{} digit estimation exceeds isize::MAX bytes. Exact = {}",


### PR DESCRIPTION
Currently, this crate's implementations of builtin integer methods take immutable references to `self`.

This PR ensures that methods in the folder `builtin_int_methods` that have potential for in-place operations distinguish between the case where `self` is moved, is a mutable reference, or is an immutable reference:
- Moved (`self`): no suffix.
- Mutable reference (`&mut self`): `_mut` suffix.
- Immutable reference (`&self`): `_ref` suffix.

This allows calling code to minimize the number of implicit memory allocations. At the moment, this crate has no defined concept of delaying the computation of a result in `_ref` type methods. This is part of the roadmap for the future.

This change is **BREAKING**.