### PR TITLE
Add convenience constructors for zero, one, and negative one

### DIFF
--- a/arbi/README.md
+++ b/arbi/README.md
@@ -29,12 +29,13 @@
 
 ### Construct an `Arbi` integer
 
-The following are all equivalent and return an [`Arbi`](https://docs.rs/arbi/latest/arbi/struct.Arbi.html) object representing the
-integer `0` (no memory allocation occurs):
+The following are equivalent and return an [`Arbi`](https://docs.rs/arbi/latest/arbi/struct.Arbi.html)
+integer with value `0` (no memory allocation occurs):
 
 - [`Arbi::new()`](https://docs.rs/arbi/latest/arbi/struct.Arbi.html#method.new)
-- [`Arbi::default()`](https://docs.rs/arbi/latest/arbi/struct.Arbi.html#method.default)
 - [`Arbi::zero()`](https://docs.rs/arbi/latest/arbi/struct.Arbi.html#method.zero)
+
+`Arbi::default()` also returns zero, but it is not `const`.
 
 ```rust
 use arbi::Arbi;

--- a/arbi/src/lib.rs
+++ b/arbi/src/lib.rs
@@ -168,10 +168,12 @@ impl Arbi {
     pub const MAX_BITS: BitCount =
         Self::MAX_CAPACITY as BitCount * Digit::BITS as BitCount;
 
-    /// The integer is initialized to zero and no memory allocation occurs.
+    /// Return an `Arbi` integer with value `0`.
     ///
-    /// Note that [`Arbi::new()`], [`Arbi::zero()`], and [`Arbi::default()`] are
-    /// all equivalent, except that `Arbi::default()` is not `const`.
+    /// No memory allocation occurs.
+    ///
+    /// [`Arbi::new()`], [`Arbi::zero()`], and [`Arbi::default()`] are
+    /// equivalent, except that `Arbi::default()` is not `const`.
     ///
     /// # Examples
     /// ```

--- a/arbi/src/lib.rs
+++ b/arbi/src/lib.rs
@@ -50,6 +50,7 @@ mod to_twos_complement;
 mod uints;
 mod unary_ops;
 mod util;
+mod zero_and_one;
 
 pub use assign::Assign;
 pub use base::{Base, BaseError};
@@ -167,16 +168,14 @@ impl Arbi {
     pub const MAX_BITS: BitCount =
         Self::MAX_CAPACITY as BitCount * Digit::BITS as BitCount;
 
-    /// Default constructor. The integer is initialized to zero and no memory
-    /// allocation occurs.
+    /// The integer is initialized to zero and no memory allocation occurs.
     ///
     /// Note that [`Arbi::new()`], [`Arbi::zero()`], and [`Arbi::default()`] are
-    /// all equivalent.
+    /// all equivalent, except that `Arbi::default()` is not `const`.
     ///
     /// # Examples
     /// ```
     /// use arbi::Arbi;
-    ///
     /// let zero = Arbi::new();
     /// assert_eq!(zero, 0);
     /// ```
@@ -184,25 +183,11 @@ impl Arbi {
     /// ## Complexity
     /// \\( O(1) \\)
     #[inline(always)]
-    pub fn new() -> Self {
-        Self::default()
-    }
-
-    /// Equivalent to [`Arbi::new()`].
-    ///
-    /// # Examples
-    /// ```
-    /// use arbi::Arbi;
-    ///
-    /// let zero = Arbi::zero();
-    /// assert_eq!(zero, 0);
-    /// ```
-    ///
-    /// ## Complexity
-    /// \\( O(1) \\)
-    #[inline(always)]
-    pub fn zero() -> Self {
-        Self::default()
+    pub const fn new() -> Self {
+        Arbi {
+            vec: Vec::new(),
+            neg: false,
+        }
     }
 
     /// Construct a new `Arbi` integer with at least the specified capacity, in

--- a/arbi/src/zero_and_one.rs
+++ b/arbi/src/zero_and_one.rs
@@ -6,27 +6,28 @@ SPDX-License-Identifier: Apache-2.0 OR MIT
 use crate::Arbi;
 
 impl Arbi {
-    /// A constant `Arbi` integer representing `0`.
+    /// A constant [`Arbi`] integer representing `0`.
     pub const ZERO: Arbi = Arbi::new();
 
+    /// Return an [`Arbi`] integer with value `0`.
+    ///
     /// Equivalent to [`Arbi::new()`].
     ///
     /// # Examples
     /// ```
     /// use arbi::Arbi;
-    ///
     /// let zero = Arbi::zero();
     /// assert_eq!(zero, 0);
     /// ```
     ///
-    /// ## Complexity
+    /// # Complexity
     /// \\( O(1) \\)
     #[inline(always)]
     pub const fn zero() -> Self {
         Arbi::new()
     }
 
-    /// Return an `Arbi` integer representing `1`.
+    /// Return an [`Arbi`] integer with value `1`.
     ///
     /// # Examples
     /// ```
@@ -42,7 +43,7 @@ impl Arbi {
         Arbi::from(1)
     }
 
-    /// Return an `Arbi` integer representing `-1`.
+    /// Return an [`Arbi`] integer with value `-1`.
     ///
     /// # Examples
     /// ```

--- a/arbi/src/zero_and_one.rs
+++ b/arbi/src/zero_and_one.rs
@@ -6,10 +6,10 @@ SPDX-License-Identifier: Apache-2.0 OR MIT
 use crate::Arbi;
 
 impl Arbi {
-    /// A constant [`Arbi`] integer representing `0`.
+    /// A constant `Arbi` integer representing `0`.
     pub const ZERO: Arbi = Arbi::new();
 
-    /// Return an [`Arbi`] integer with value `0`.
+    /// Return an `Arbi` integer with value `0`.
     ///
     /// Equivalent to [`Arbi::new()`].
     ///
@@ -27,7 +27,7 @@ impl Arbi {
         Arbi::new()
     }
 
-    /// Return an [`Arbi`] integer with value `1`.
+    /// Return an `Arbi` integer with value `1`.
     ///
     /// # Examples
     /// ```
@@ -43,7 +43,7 @@ impl Arbi {
         Arbi::from(1)
     }
 
-    /// Return an [`Arbi`] integer with value `-1`.
+    /// Return an `Arbi` integer with value `-1`.
     ///
     /// # Examples
     /// ```

--- a/arbi/src/zero_and_one.rs
+++ b/arbi/src/zero_and_one.rs
@@ -1,0 +1,60 @@
+/*
+Copyright 2024 Owain Davies
+SPDX-License-Identifier: Apache-2.0 OR MIT
+*/
+
+use crate::Arbi;
+
+impl Arbi {
+    /// A constant `Arbi` integer representing `0`.
+    pub const ZERO: Arbi = Arbi::new();
+
+    /// Equivalent to [`Arbi::new()`].
+    ///
+    /// # Examples
+    /// ```
+    /// use arbi::Arbi;
+    ///
+    /// let zero = Arbi::zero();
+    /// assert_eq!(zero, 0);
+    /// ```
+    ///
+    /// ## Complexity
+    /// \\( O(1) \\)
+    #[inline(always)]
+    pub const fn zero() -> Self {
+        Arbi::new()
+    }
+
+    /// Return an `Arbi` integer representing `1`.
+    ///
+    /// # Examples
+    /// ```
+    /// use arbi::Arbi;
+    /// let one = Arbi::one();
+    /// assert_eq!(one, 1);
+    /// ```
+    ///
+    /// # Complexity
+    /// \\( O(1) \\)
+    #[inline(always)]
+    pub fn one() -> Self {
+        Arbi::from(1)
+    }
+
+    /// Return an `Arbi` integer representing `-1`.
+    ///
+    /// # Examples
+    /// ```
+    /// use arbi::Arbi;
+    /// let neg_one = Arbi::neg_one();
+    /// assert_eq!(neg_one, -1);
+    /// ```
+    ///
+    /// # Complexity
+    /// \\( O(1) \\)
+    #[inline(always)]
+    pub fn neg_one() -> Self {
+        Arbi::from(-1)
+    }
+}


### PR DESCRIPTION
* Adds constructors for zero, one, and negative one.
* Zero constructor is `const`, the other two are not.
* Also adds the `ZERO` associated constant for `Arbi`.