### PR TITLE
Use specialized functions for add and sub ops and improve its private docs

### DIFF
--- a/arbi/src/add.rs
+++ b/arbi/src/add.rs
@@ -207,7 +207,7 @@ impl<'b> Add<&'b Arbi> for &Arbi {
 /// let a = Arbi::from(-123456);
 /// let b = Arbi::from(1234567);
 /// let b_cap = b.capacity();
-/// let c = &a + b; // In this case, no memory allocation occurs (b's memory is
+/// let c = &a + b; // In this case, no memory allocation (b's memory is
 ///                 // used.
 /// assert_eq!(c, 1111111);
 /// assert_eq!(c.capacity(), b_cap);
@@ -277,7 +277,7 @@ impl<'a> AddAssign<&'a Arbi> for Arbi {
 /// let a = Arbi::from(-1234567);
 /// let a_cap = a.capacity();
 /// let b = Arbi::from(-123456);
-/// let c = a - b; // no memory allocation occurs
+/// let c = a - b; // no memory allocation
 /// assert_eq!(c, -1111111);
 /// assert_eq!(c.capacity(), a_cap);
 /// ```
@@ -300,7 +300,7 @@ impl Sub<Arbi> for Arbi {
 /// let a = Arbi::from(-1234567);
 /// let a_cap = a.capacity();
 /// let b = Arbi::from(-123456);
-/// let c = a - &b; // no memory allocation occurs
+/// let c = a - &b; // no memory allocation
 /// assert_eq!(c, -1111111);
 /// assert_eq!(c.capacity(), a_cap);
 /// ```
@@ -323,7 +323,7 @@ impl<'a> Sub<&'a Arbi> for Arbi {
 /// use arbi::Arbi;
 /// let a = Arbi::from(-1234567);
 /// let b = Arbi::from(-123456);
-/// let c = &a - &b; // memory allocation occurs
+/// let c = &a - &b; // memory allocation
 /// assert_eq!(c, -1111111);
 /// ```
 ///
@@ -337,7 +337,7 @@ impl<'b> Sub<&'b Arbi> for &Arbi {
     }
 }
 
-/// Implements `&self + rhs`.
+/// Implements `&self - rhs`.
 ///
 /// # Examples
 /// ```

--- a/arbi/src/add.rs
+++ b/arbi/src/add.rs
@@ -198,6 +198,39 @@ impl<'b> Add<&'b Arbi> for &Arbi {
     }
 }
 
+/// Implements `&self + rhs`.
+///
+/// # Examples
+/// ```
+/// use arbi::{Arbi, Digit};
+///
+/// let a = Arbi::from(-123456);
+/// let b = Arbi::from(1234567);
+/// let b_cap = b.capacity();
+/// let c = &a + b; // In this case, no memory allocation occurs (b's memory is
+///                 // used.
+/// assert_eq!(c, 1111111);
+/// assert_eq!(c.capacity(), b_cap);
+///
+/// let a = Arbi::from(-(Digit::MAX as i128));
+/// let b = Arbi::from(-1234567);
+/// let b_cap = b.capacity();
+/// let c = &a + b; // In this case, memory allocation may or may not occur,
+///                 // depending on b's capacity.
+/// assert!(c.capacity() >= b_cap);
+/// ```
+///
+/// # Complexity
+/// \\( O(n) \\)
+impl Add<Arbi> for &Arbi {
+    type Output = Arbi;
+
+    fn add(self, mut other: Arbi) -> Arbi {
+        other.add_mut(self);
+        other
+    }
+}
+
 /// Implements `self += rhs`.
 ///
 /// # Examples
@@ -313,7 +346,7 @@ impl<'b> Sub<&'b Arbi> for &Arbi {
 /// let a = Arbi::from(1234567);
 /// let b = Arbi::from(123456);
 /// let b_cap = b.capacity();
-/// let c = &a - b; // In this case, no memory allocation occurs (b's memory is
+/// let c = &a - b; // In this case, no memory allocation (b's memory is
 ///                 // used.
 /// assert_eq!(c, 1111111);
 /// assert_eq!(c.capacity(), b_cap);
@@ -321,9 +354,8 @@ impl<'b> Sub<&'b Arbi> for &Arbi {
 /// let a = Arbi::from(-(Digit::MAX as i128));
 /// let b = Arbi::from(-1234567);
 /// let b_cap = b.capacity();
-/// let c = &a - b; // In this case, memory allocation may or may not occur,
-///                 // depending on b's capacity.
-/// assert!(c.capacity() >= b_cap);
+/// let c = &a - b; // In this case, no memory allocation
+/// assert_eq!(c.capacity(), b_cap);
 /// ```
 ///
 /// # Complexity

--- a/arbi/src/lib.rs
+++ b/arbi/src/lib.rs
@@ -180,4 +180,14 @@ impl Arbi {
         self.vec[0] = 1;
         self.neg = neg;
     }
+
+    /// Same as cloning but ensuring a given capacity prior.
+    pub(crate) fn with_capacity_and_copy(capacity: usize, arbi: &Arbi) -> Self {
+        let mut new_vec = Vec::with_capacity(capacity);
+        new_vec.extend_from_slice(&arbi.vec);
+        Self {
+            vec: new_vec,
+            neg: arbi.neg,
+        }
+    }
 }


### PR DESCRIPTION
It's not always clear by looking at a private function name whether it sets `self.neg` or not. This adds documentation that includes the mathematical meaning behind each operation.

Moreover, specialized functions are created to help express the most efficient option, given the types of the operands.