### PR TITLE
Implement div and rem with primitive integer types

### DIFF
--- a/arbi/src/builtin_int_methods/euclid_div_and_rem.rs
+++ b/arbi/src/builtin_int_methods/euclid_div_and_rem.rs
@@ -144,7 +144,7 @@ impl Arbi {
     /// # Complexity
     /// \\( O(m \cdot n) \\)
     pub fn divrem_euclid_ref(&self, rhs: &Self) -> (Arbi, Arbi) {
-        let (mut quot, mut rem) = self.div(rhs);
+        let (mut quot, mut rem) = self.divrem(rhs);
         if rem.is_negative() {
             if rhs.is_negative() {
                 // rhs < 0

--- a/arbi/src/division.rs
+++ b/arbi/src/division.rs
@@ -99,8 +99,8 @@ impl Arbi {
 
         let compl_e: u32 = Digit::BITS - e;
 
-        let mut u_norm = Arbi::default();
-        let mut v_norm = Arbi::default();
+        let mut u_norm = Arbi::zero();
+        let mut v_norm = Arbi::zero();
         u_norm.vec.resize(m + 1, 0);
         v_norm.vec.resize(n, 0);
 
@@ -252,8 +252,8 @@ impl core::ops::Div<Arbi> for Arbi {
     type Output = Arbi;
 
     fn div(self, rhs: Arbi) -> Arbi {
-        let mut quot: Arbi = Arbi::default();
-        let mut rem: Arbi = Arbi::default();
+        let mut quot: Arbi = Arbi::zero();
+        let mut rem: Arbi = Arbi::zero();
         Self::divide(&mut quot, &mut rem, &self, &rhs);
         quot
     }
@@ -264,8 +264,8 @@ impl<'a> core::ops::Div<&'a Arbi> for Arbi {
     type Output = Arbi;
 
     fn div(self, rhs: &'a Arbi) -> Arbi {
-        let mut quot: Arbi = Arbi::default();
-        let mut rem: Arbi = Arbi::default();
+        let mut quot: Arbi = Arbi::zero();
+        let mut rem: Arbi = Arbi::zero();
         Self::divide(&mut quot, &mut rem, &self, rhs);
         quot
     }
@@ -276,8 +276,8 @@ impl<'a> core::ops::Div<&'a Arbi> for &Arbi {
     type Output = Arbi;
 
     fn div(self, rhs: &'a Arbi) -> Arbi {
-        let mut quot: Arbi = Arbi::default();
-        let mut rem: Arbi = Arbi::default();
+        let mut quot: Arbi = Arbi::zero();
+        let mut rem: Arbi = Arbi::zero();
         Arbi::divide(&mut quot, &mut rem, self, rhs);
         quot
     }
@@ -286,8 +286,8 @@ impl<'a> core::ops::Div<&'a Arbi> for &Arbi {
 /// See the [`div()`](#method.div) method.
 impl core::ops::DivAssign<Arbi> for Arbi {
     fn div_assign(&mut self, rhs: Arbi) {
-        let mut quot: Arbi = Arbi::default();
-        let mut rem: Arbi = Arbi::default();
+        let mut quot: Arbi = Arbi::zero();
+        let mut rem: Arbi = Arbi::zero();
         Self::divide(&mut quot, &mut rem, self, &rhs);
         *self = quot;
     }
@@ -296,8 +296,8 @@ impl core::ops::DivAssign<Arbi> for Arbi {
 /// See the [`div()`](#method.div) method.
 impl<'a> core::ops::DivAssign<&'a Arbi> for Arbi {
     fn div_assign(&mut self, rhs: &'a Arbi) {
-        let mut quot: Arbi = Arbi::default();
-        let mut rem: Arbi = Arbi::default();
+        let mut quot: Arbi = Arbi::zero();
+        let mut rem: Arbi = Arbi::zero();
         Self::divide(&mut quot, &mut rem, self, rhs);
         *self = quot;
     }
@@ -308,8 +308,8 @@ impl core::ops::Rem<Arbi> for Arbi {
     type Output = Arbi;
 
     fn rem(self, rhs: Arbi) -> Arbi {
-        let mut quot: Arbi = Arbi::default();
-        let mut rem: Arbi = Arbi::default();
+        let mut quot: Arbi = Arbi::zero();
+        let mut rem: Arbi = Arbi::zero();
         Self::divide(&mut quot, &mut rem, &self, &rhs);
         rem
     }
@@ -320,8 +320,8 @@ impl<'a> core::ops::Rem<&'a Arbi> for Arbi {
     type Output = Arbi;
 
     fn rem(self, rhs: &'a Arbi) -> Arbi {
-        let mut quot: Arbi = Arbi::default();
-        let mut rem: Arbi = Arbi::default();
+        let mut quot: Arbi = Arbi::zero();
+        let mut rem: Arbi = Arbi::zero();
         Self::divide(&mut quot, &mut rem, &self, rhs);
         rem
     }
@@ -332,8 +332,8 @@ impl<'a> core::ops::Rem<&'a Arbi> for &Arbi {
     type Output = Arbi;
 
     fn rem(self, rhs: &'a Arbi) -> Arbi {
-        let mut quot: Arbi = Arbi::default();
-        let mut rem: Arbi = Arbi::default();
+        let mut quot: Arbi = Arbi::zero();
+        let mut rem: Arbi = Arbi::zero();
         Arbi::divide(&mut quot, &mut rem, self, rhs);
         rem
     }
@@ -342,8 +342,8 @@ impl<'a> core::ops::Rem<&'a Arbi> for &Arbi {
 /// See the [`div()`](#method.div) method.
 impl core::ops::RemAssign<Arbi> for Arbi {
     fn rem_assign(&mut self, rhs: Arbi) {
-        let mut quot: Arbi = Arbi::default();
-        let mut rem: Arbi = Arbi::default();
+        let mut quot: Arbi = Arbi::zero();
+        let mut rem: Arbi = Arbi::zero();
         Self::divide(&mut quot, &mut rem, self, &rhs);
         *self = rem;
     }
@@ -352,8 +352,8 @@ impl core::ops::RemAssign<Arbi> for Arbi {
 /// See the [`div()`](#method.div) method.
 impl<'a> core::ops::RemAssign<&'a Arbi> for Arbi {
     fn rem_assign(&mut self, rhs: &'a Arbi) {
-        let mut quot: Arbi = Arbi::default();
-        let mut rem: Arbi = Arbi::default();
+        let mut quot: Arbi = Arbi::zero();
+        let mut rem: Arbi = Arbi::zero();
         Self::divide(&mut quot, &mut rem, self, rhs);
         *self = rem;
     }
@@ -493,8 +493,8 @@ impl Arbi {
     /// ## Complexity
     /// \\( O(m \cdot n) \\)
     pub fn div(&self, other: &Arbi) -> (Arbi, Arbi) {
-        let mut quot: Arbi = Arbi::default();
-        let mut rem: Arbi = Arbi::default();
+        let mut quot: Arbi = Arbi::zero();
+        let mut rem: Arbi = Arbi::zero();
         Self::divide(&mut quot, &mut rem, self, other);
         (quot, rem)
     }

--- a/arbi/src/division.rs
+++ b/arbi/src/division.rs
@@ -3,7 +3,9 @@ Copyright 2024 Owain Davies
 SPDX-License-Identifier: Apache-2.0 OR MIT
 */
 
+use crate::util::to_digits::{length_digits, ToDigits};
 use crate::{Arbi, BitCount, DDigit, Digit, SDDigit};
+use core::ops::{Div, DivAssign, Rem, RemAssign};
 
 impl Arbi {
     fn ddiv_algo_single(q: &mut Self, r: &mut Self, u: &[Digit], v: &[Digit]) {
@@ -258,7 +260,7 @@ impl Arbi {
 }
 
 /// See the [`div()`](#method.div) method.
-impl core::ops::Div<Arbi> for Arbi {
+impl Div<Arbi> for Arbi {
     type Output = Arbi;
 
     fn div(self, rhs: Arbi) -> Arbi {
@@ -270,7 +272,7 @@ impl core::ops::Div<Arbi> for Arbi {
 }
 
 /// See the [`div()`](#method.div) method.
-impl<'a> core::ops::Div<&'a Arbi> for Arbi {
+impl<'a> Div<&'a Arbi> for Arbi {
     type Output = Arbi;
 
     fn div(self, rhs: &'a Arbi) -> Arbi {
@@ -282,7 +284,7 @@ impl<'a> core::ops::Div<&'a Arbi> for Arbi {
 }
 
 /// See the [`div()`](#method.div) method.
-impl<'a> core::ops::Div<&'a Arbi> for &Arbi {
+impl<'a> Div<&'a Arbi> for &Arbi {
     type Output = Arbi;
 
     fn div(self, rhs: &'a Arbi) -> Arbi {
@@ -294,7 +296,7 @@ impl<'a> core::ops::Div<&'a Arbi> for &Arbi {
 }
 
 /// See the [`div()`](#method.div) method.
-impl core::ops::DivAssign<Arbi> for Arbi {
+impl DivAssign<Arbi> for Arbi {
     fn div_assign(&mut self, rhs: Arbi) {
         let mut quot: Arbi = Arbi::zero();
         let mut rem: Arbi = Arbi::zero();
@@ -304,7 +306,7 @@ impl core::ops::DivAssign<Arbi> for Arbi {
 }
 
 /// See the [`div()`](#method.div) method.
-impl<'a> core::ops::DivAssign<&'a Arbi> for Arbi {
+impl<'a> DivAssign<&'a Arbi> for Arbi {
     fn div_assign(&mut self, rhs: &'a Arbi) {
         let mut quot: Arbi = Arbi::zero();
         let mut rem: Arbi = Arbi::zero();
@@ -314,7 +316,7 @@ impl<'a> core::ops::DivAssign<&'a Arbi> for Arbi {
 }
 
 /// See the [`div()`](#method.div) method.
-impl core::ops::Rem<Arbi> for Arbi {
+impl Rem<Arbi> for Arbi {
     type Output = Arbi;
 
     fn rem(self, rhs: Arbi) -> Arbi {
@@ -326,7 +328,7 @@ impl core::ops::Rem<Arbi> for Arbi {
 }
 
 /// See the [`div()`](#method.div) method.
-impl<'a> core::ops::Rem<&'a Arbi> for Arbi {
+impl<'a> Rem<&'a Arbi> for Arbi {
     type Output = Arbi;
 
     fn rem(self, rhs: &'a Arbi) -> Arbi {
@@ -338,7 +340,7 @@ impl<'a> core::ops::Rem<&'a Arbi> for Arbi {
 }
 
 /// See the [`div()`](#method.div) method.
-impl<'a> core::ops::Rem<&'a Arbi> for &Arbi {
+impl<'a> Rem<&'a Arbi> for &Arbi {
     type Output = Arbi;
 
     fn rem(self, rhs: &'a Arbi) -> Arbi {
@@ -350,7 +352,7 @@ impl<'a> core::ops::Rem<&'a Arbi> for &Arbi {
 }
 
 /// See the [`div()`](#method.div) method.
-impl core::ops::RemAssign<Arbi> for Arbi {
+impl RemAssign<Arbi> for Arbi {
     fn rem_assign(&mut self, rhs: Arbi) {
         let mut quot: Arbi = Arbi::zero();
         let mut rem: Arbi = Arbi::zero();
@@ -360,7 +362,7 @@ impl core::ops::RemAssign<Arbi> for Arbi {
 }
 
 /// See the [`div()`](#method.div) method.
-impl<'a> core::ops::RemAssign<&'a Arbi> for Arbi {
+impl<'a> RemAssign<&'a Arbi> for Arbi {
     fn rem_assign(&mut self, rhs: &'a Arbi) {
         let mut quot: Arbi = Arbi::zero();
         let mut rem: Arbi = Arbi::zero();
@@ -459,7 +461,7 @@ impl Arbi {
     ///     Arbi::from_str_radix("40000000000000000000000000000000000000", 16)
     ///         .unwrap();
     ///
-    /// let (quo, rem) = num.div(&den);
+    /// let (quo, rem) = num.divrem(&den);
     /// assert_eq!(quo, 1125899906842624_u64);
     /// assert_eq!(rem, 0);
     ///
@@ -470,7 +472,7 @@ impl Arbi {
     ///     panic!("Parse error: {}", e);
     /// }
     ///
-    /// let (quo, rem) = num.div(&den);
+    /// let (quo, rem) = num.divrem(&den);
     /// let expected_rem = Arbi::from_str_radix(
     ///     "54e92bc47a9d2e49a6543c40fc47666d59b2c38caac071917",
     ///     16,
@@ -490,7 +492,7 @@ impl Arbi {
     /// use arbi::Arbi;
     ///
     /// let x = Arbi::from_str_radix("123456789", 10).unwrap();
-    /// let (quo, rem) = x.div(&Arbi::zero());
+    /// let (quo, rem) = x.divrem(&Arbi::zero());
     /// ```
     ///
     /// Dividing a primitive integer value by zero panics:
@@ -502,7 +504,7 @@ impl Arbi {
     ///
     /// ## Complexity
     /// \\( O(m \cdot n) \\)
-    pub fn div(&self, other: &Arbi) -> (Arbi, Arbi) {
+    pub fn divrem(&self, other: &Arbi) -> (Arbi, Arbi) {
         let mut quot: Arbi = Arbi::zero();
         let mut rem: Arbi = Arbi::zero();
         Self::divide(&mut quot, &mut rem, self, other);
@@ -520,26 +522,26 @@ mod test_divrem {
     #[test]
     #[should_panic]
     fn test_div_by_zero() {
-        Arbi::from(10).div(&Arbi::zero());
+        Arbi::from(10).divrem(&Arbi::zero());
     }
 
     #[test]
     fn test_misc() {
-        let (quot, rem) = Arbi::from(10).div(&Arbi::from(-2));
+        let (quot, rem) = Arbi::from(10).divrem(&Arbi::from(-2));
         assert_eq!(quot, -5);
         assert_eq!(rem, 0);
 
-        let (quot, rem) = Arbi::from(SDDigit::MIN).div(&Arbi::neg_one());
+        let (quot, rem) = Arbi::from(SDDigit::MIN).divrem(&Arbi::neg_one());
         assert_eq!(quot, 1 as DDigit + SDDigit::MAX as DDigit);
         assert_eq!(rem, 0);
 
-        let (quot, rem) = Arbi::from(10).div(&Arbi::from(3));
+        let (quot, rem) = Arbi::from(10).divrem(&Arbi::from(3));
         assert_eq!(quot, 3);
         assert_eq!(rem, 1);
 
         let (a_in, b_in) =
             (13565672763181344623_u128, 10964129492588451979_u128);
-        let (quot, rem) = Arbi::from(a_in).div(&Arbi::from(b_in));
+        let (quot, rem) = Arbi::from(a_in).divrem(&Arbi::from(b_in));
         assert_eq!(quot, a_in / b_in);
         assert_eq!(rem, a_in % b_in);
     }
@@ -551,7 +553,7 @@ mod test_divrem {
         let a = Arbi::from_str_base("237634993259031120016359157450036169713011146626949272664357175750540350033099851627590", BASE10).unwrap();
         let b = Arbi::from_str_base("62391207566730956436059735556895094403209083705277492693463432131493682000515", BASE10).unwrap();
 
-        let (quot, rem) = a.div(&b);
+        let (quot, rem) = a.divrem(&b);
 
         assert_eq!(quot, 3808789772_i64);
         assert_eq!(rem, Arbi::from_str_base("16137245666917264679909410073093944632796496071688924192091054946917820895010", BASE10).unwrap());
@@ -565,7 +567,7 @@ mod test_divrem {
             Arbi::from_str_base("1208925820177561948258300", BASE10).unwrap();
         let b = Arbi::from_str_base("281474976841724", BASE10).unwrap();
 
-        let (quot, rem) = a.div(&b);
+        let (quot, rem) = a.divrem(&b);
 
         assert_eq!(quot, 4294967295_u64);
         assert_eq!(rem, 281474976841720_u64);
@@ -578,7 +580,7 @@ mod test_divrem {
         let b =
             Arbi::from_str_base("77371252455336267181195265", BASE10).unwrap();
 
-        let (quot, rem) = a.div(&b);
+        let (quot, rem) = a.divrem(&b);
 
         assert_eq!(quot, 15362);
         assert_eq!(rem, 77371252455336267181179904_u128);
@@ -612,7 +614,7 @@ mod test_divrem {
                     continue;
                 }
 
-                let (quot, rem) = a.div(&b);
+                let (quot, rem) = a.divrem(&b);
 
                 assert_eq!(
                     quot,
@@ -632,3 +634,221 @@ mod test_divrem {
         }
     }
 }
+
+/* !impl_arbi_div_for_primitive */
+macro_rules! impl_arbi_div_for_primitive {
+    ($($signed_type:ty),* ) => {
+        $(
+
+impl Div<$signed_type> for Arbi {
+    type Output = Self;
+    #[allow(unused_comparisons)]
+    fn div(self, other: $signed_type) -> Self {
+        match other.to_digits() {
+            None => panic!("Division by zero attempt."),
+            Some(v) => {
+                let v_len: usize = length_digits(&v);
+                let mut quo = Arbi::zero();
+                let mut rem = Arbi::zero();
+                Self::ddivide(
+                    &mut quo,
+                    &mut rem,
+                    &self.vec,
+                    &v[..v_len],
+                    self.is_negative(),
+                    other < 0,
+                );
+                quo
+            }
+        }
+    }
+}
+
+impl Div<&$signed_type> for Arbi {
+    type Output = Self;
+    fn div(self, other: &$signed_type) -> Self {
+        self / (*other)
+    }
+}
+
+impl Div<$signed_type> for &Arbi {
+    type Output = Arbi;
+    fn div(self, other: $signed_type) -> Arbi {
+        self.clone() / other
+    }
+}
+
+impl Div<&$signed_type> for &Arbi {
+    type Output = Arbi;
+    fn div(self, other: &$signed_type) -> Arbi {
+        self.clone() / (*other)
+    }
+}
+
+impl Div<Arbi> for $signed_type {
+    type Output = Arbi;
+    fn div(self, other: Arbi) -> Arbi {
+        self / &other
+    }
+}
+
+impl Div<&Arbi> for $signed_type {
+    type Output = Arbi;
+    fn div(self, other: &Arbi) -> Arbi {
+        Arbi::from(self) / other
+    }
+}
+
+impl Div<Arbi> for &$signed_type {
+    type Output = Arbi;
+    fn div(self, other: Arbi) -> Arbi {
+        (*self) / other
+    }
+}
+
+impl Div<&Arbi> for &$signed_type {
+    type Output = Arbi;
+    fn div(self, other: &Arbi) -> Arbi {
+        (*self) / other
+    }
+}
+
+impl DivAssign<&$signed_type> for Arbi {
+    fn div_assign(&mut self, other: &$signed_type) {
+        self.div_assign(*other);
+    }
+}
+
+impl DivAssign<$signed_type> for Arbi {
+    #[allow(unused_comparisons)]
+    fn div_assign(&mut self, other: $signed_type) {
+        match other.to_digits() {
+            None => panic!("Division by zero attempt."),
+            Some(v) => {
+                let v_len: usize = length_digits(&v);
+                let mut quo = Arbi::zero();
+                let mut rem = Arbi::zero();
+                Self::ddivide(
+                    &mut quo,
+                    &mut rem,
+                    &self.vec,
+                    &v[..v_len],
+                    self.is_negative(),
+                    other < 0,
+                );
+                *self = quo;
+            }
+        }
+    }
+}
+
+impl Rem<$signed_type> for Arbi {
+    type Output = Self;
+    #[allow(unused_comparisons)]
+    fn rem(self, other: $signed_type) -> Self {
+        match other.to_digits() {
+            None => panic!("Division by zero attempt."),
+            Some(v) => {
+                let v_len: usize = length_digits(&v);
+                let mut quo = Arbi::zero();
+                let mut rem = Arbi::zero();
+                Self::ddivide(
+                    &mut quo,
+                    &mut rem,
+                    &self.vec,
+                    &v[..v_len],
+                    self.is_negative(),
+                    other < 0,
+                );
+                rem
+            }
+        }
+    }
+}
+
+impl Rem<&$signed_type> for Arbi {
+    type Output = Self;
+    fn rem(self, other: &$signed_type) -> Self {
+        self % (*other)
+    }
+}
+
+impl Rem<$signed_type> for &Arbi {
+    type Output = Arbi;
+    fn rem(self, other: $signed_type) -> Arbi {
+        self.clone() % other
+    }
+}
+
+impl Rem<&$signed_type> for &Arbi {
+    type Output = Arbi;
+    fn rem(self, other: &$signed_type) -> Arbi {
+        self.clone() % (*other)
+    }
+}
+
+impl Rem<Arbi> for $signed_type {
+    type Output = Arbi;
+    fn rem(self, other: Arbi) -> Arbi {
+        self % &other
+    }
+}
+
+impl Rem<&Arbi> for $signed_type {
+    type Output = Arbi;
+    fn rem(self, other: &Arbi) -> Arbi {
+        Arbi::from(self) % other
+    }
+}
+
+impl Rem<Arbi> for &$signed_type {
+    type Output = Arbi;
+    fn rem(self, other: Arbi) -> Arbi {
+        (*self) % other
+    }
+}
+
+impl Rem<&Arbi> for &$signed_type {
+    type Output = Arbi;
+    fn rem(self, other: &Arbi) -> Arbi {
+        (*self) % other
+    }
+}
+
+impl RemAssign<&$signed_type> for Arbi {
+    fn rem_assign(&mut self, other: &$signed_type) {
+        self.div_assign(*other);
+    }
+}
+
+impl RemAssign<$signed_type> for Arbi {
+    #[allow(unused_comparisons)]
+    fn rem_assign(&mut self, other: $signed_type) {
+        match other.to_digits() {
+            None => panic!("Division by zero attempt."),
+            Some(v) => {
+                let v_len: usize = length_digits(&v);
+                let mut quo = Arbi::zero();
+                let mut rem = Arbi::zero();
+                Self::ddivide(
+                    &mut quo,
+                    &mut rem,
+                    &self.vec,
+                    &v[..v_len],
+                    self.is_negative(),
+                    other < 0,
+                );
+                *self = rem;
+            }
+        }
+    }
+}
+
+        )*
+    }
+}
+/* impl_arbi_div_for_primitive! */
+
+impl_arbi_div_for_primitive![
+    i8, u8, i16, u16, i32, u32, i64, u64, i128, u128, isize, usize
+];

--- a/arbi/src/division.rs
+++ b/arbi/src/division.rs
@@ -904,37 +904,52 @@ mod $test_module {
             if (lhs as i128 == i128::MIN) && (r as i128 == -1) {
                 continue;
             }
-            let lhs_arbi = Arbi::from(lhs);
+            let mut lhs_arbi = Arbi::from(lhs);
             let expected_div = lhs as SQDigit / r as SQDigit;
             let expected_rem = lhs as SQDigit % r as SQDigit;
             assert_eq!(&lhs_arbi / r, expected_div);
             assert_eq!(&lhs_arbi % r, expected_rem);
             assert_eq!(lhs_arbi.clone() / r, expected_div);
-            assert_eq!(lhs_arbi % r, expected_rem);
+            assert_eq!(lhs_arbi.clone() % r, expected_rem);
+            let mut lhs_arbi_clone = lhs_arbi.clone();
+            lhs_arbi_clone /= r;
+            assert_eq!(lhs_arbi_clone, expected_div);
+            lhs_arbi %= r;
+            assert_eq!(lhs_arbi, expected_rem);
 
             let lhs = die_sddigit.sample(&mut rng);
             if (lhs as i128 == i128::MIN) && (r as i128 == -1) {
                 continue;
             }
-            let lhs_arbi = Arbi::from(lhs);
+            let mut lhs_arbi = Arbi::from(lhs);
             let expected_div = lhs as SQDigit / r as SQDigit;
             let expected_rem = lhs as SQDigit % r as SQDigit;
             assert_eq!(&lhs_arbi / r, expected_div);
             assert_eq!(&lhs_arbi % r, expected_rem);
             assert_eq!(lhs_arbi.clone() / r, expected_div);
-            assert_eq!(lhs_arbi % r, expected_rem);
+            assert_eq!(lhs_arbi.clone() % r, expected_rem);
+            let mut lhs_arbi_clone = lhs_arbi.clone();
+            lhs_arbi_clone /= r;
+            assert_eq!(lhs_arbi_clone, expected_div);
+            lhs_arbi %= r;
+            assert_eq!(lhs_arbi, expected_rem);
 
             let lhs = die_sqdigit.sample(&mut rng);
             if (lhs as i128 == i128::MIN) && (r as i128 == -1) {
                 continue;
             }
-            let lhs_arbi = Arbi::from(lhs);
+            let mut lhs_arbi = Arbi::from(lhs);
             let expected_div = lhs as SQDigit / r as SQDigit;
             let expected_rem = lhs as SQDigit % r as SQDigit;
             assert_eq!(&lhs_arbi / r, expected_div);
             assert_eq!(&lhs_arbi % r, expected_rem);
             assert_eq!(lhs_arbi.clone() / r, expected_div);
-            assert_eq!(lhs_arbi % r, expected_rem);
+            assert_eq!(lhs_arbi.clone() % r, expected_rem);
+            let mut lhs_arbi_clone = lhs_arbi.clone();
+            lhs_arbi_clone /= r;
+            assert_eq!(lhs_arbi_clone, expected_div);
+            lhs_arbi %= r;
+            assert_eq!(lhs_arbi, expected_rem);
         }
     }
 

--- a/arbi/src/division.rs
+++ b/arbi/src/division.rs
@@ -884,6 +884,29 @@ mod $test_module {
         let _ = &n % zero;
     }
 
+    macro_rules! test_div_rem {
+        ($lhs:expr, $r:expr) => {{
+            if ($lhs as i128 == i128::MIN) && ($r as i128 == -1) {
+                continue;
+            }
+
+            let mut lhs_arbi = Arbi::from($lhs);
+            let expected_div = $lhs as SQDigit / $r as SQDigit;
+            let expected_rem = $lhs as SQDigit % $r as SQDigit;
+
+            assert_eq!(&lhs_arbi / $r, expected_div);
+            assert_eq!(&lhs_arbi % $r, expected_rem);
+            assert_eq!(lhs_arbi.clone() / $r, expected_div);
+            assert_eq!(lhs_arbi.clone() % $r, expected_rem);
+
+            let mut lhs_arbi_clone = lhs_arbi.clone();
+            lhs_arbi_clone /= $r;
+            assert_eq!(lhs_arbi_clone, expected_div);
+            lhs_arbi %= $r;
+            assert_eq!(lhs_arbi, expected_rem);
+        }};
+    }
+
     #[test]
     fn smoke() {
         let (mut rng, _) = get_seedable_rng();
@@ -901,56 +924,29 @@ mod $test_module {
             }
 
             let lhs = die_sdigit.sample(&mut rng);
-            if (lhs as i128 == i128::MIN) && (r as i128 == -1) {
-                continue;
-            }
-            let mut lhs_arbi = Arbi::from(lhs);
-            let expected_div = lhs as SQDigit / r as SQDigit;
-            let expected_rem = lhs as SQDigit % r as SQDigit;
-            assert_eq!(&lhs_arbi / r, expected_div);
-            assert_eq!(&lhs_arbi % r, expected_rem);
-            assert_eq!(lhs_arbi.clone() / r, expected_div);
-            assert_eq!(lhs_arbi.clone() % r, expected_rem);
-            let mut lhs_arbi_clone = lhs_arbi.clone();
-            lhs_arbi_clone /= r;
-            assert_eq!(lhs_arbi_clone, expected_div);
-            lhs_arbi %= r;
-            assert_eq!(lhs_arbi, expected_rem);
+            test_div_rem!(lhs, r);
 
             let lhs = die_sddigit.sample(&mut rng);
-            if (lhs as i128 == i128::MIN) && (r as i128 == -1) {
-                continue;
-            }
-            let mut lhs_arbi = Arbi::from(lhs);
-            let expected_div = lhs as SQDigit / r as SQDigit;
-            let expected_rem = lhs as SQDigit % r as SQDigit;
-            assert_eq!(&lhs_arbi / r, expected_div);
-            assert_eq!(&lhs_arbi % r, expected_rem);
-            assert_eq!(lhs_arbi.clone() / r, expected_div);
-            assert_eq!(lhs_arbi.clone() % r, expected_rem);
-            let mut lhs_arbi_clone = lhs_arbi.clone();
-            lhs_arbi_clone /= r;
-            assert_eq!(lhs_arbi_clone, expected_div);
-            lhs_arbi %= r;
-            assert_eq!(lhs_arbi, expected_rem);
+            test_div_rem!(lhs, r);
 
             let lhs = die_sqdigit.sample(&mut rng);
-            if (lhs as i128 == i128::MIN) && (r as i128 == -1) {
+            test_div_rem!(lhs, r);
+        }
+    }
+
+    macro_rules! test_div_rem_prim_lhs {
+        ($lhs:expr, $rhs:expr) => {{
+            if $rhs == 0 {
                 continue;
             }
-            let mut lhs_arbi = Arbi::from(lhs);
-            let expected_div = lhs as SQDigit / r as SQDigit;
-            let expected_rem = lhs as SQDigit % r as SQDigit;
-            assert_eq!(&lhs_arbi / r, expected_div);
-            assert_eq!(&lhs_arbi % r, expected_rem);
-            assert_eq!(lhs_arbi.clone() / r, expected_div);
-            assert_eq!(lhs_arbi.clone() % r, expected_rem);
-            let mut lhs_arbi_clone = lhs_arbi.clone();
-            lhs_arbi_clone /= r;
-            assert_eq!(lhs_arbi_clone, expected_div);
-            lhs_arbi %= r;
-            assert_eq!(lhs_arbi, expected_rem);
-        }
+            let rhs_arbi = Arbi::from($rhs);
+            let expected_div = $lhs as SQDigit / $rhs as SQDigit;
+            let expected_rem = $lhs as SQDigit % $rhs as SQDigit;
+            assert_eq!($lhs / &rhs_arbi, expected_div);
+            assert_eq!($lhs % &rhs_arbi, expected_rem);
+            assert_eq!($lhs / rhs_arbi.clone(), expected_div);
+            assert_eq!($lhs % rhs_arbi, expected_rem);
+        }};
     }
 
     #[test]
@@ -967,40 +963,13 @@ mod $test_module {
             }
 
             let rhs = die_sqdigit.sample(&mut rng);
-            if rhs == 0 {
-                continue;
-            }
-            let rhs_arbi = Arbi::from(rhs);
-            let expected_div = lhs as SQDigit / rhs as SQDigit;
-            let expected_rem = lhs as SQDigit % rhs as SQDigit;
-            assert_eq!(lhs / &rhs_arbi, expected_div);
-            assert_eq!(lhs % &rhs_arbi, expected_rem);
-            assert_eq!(lhs / rhs_arbi.clone(), expected_div);
-            assert_eq!(lhs % rhs_arbi, expected_rem);
+            test_div_rem_prim_lhs!(lhs, rhs);
 
             let rhs = die_sddigit.sample(&mut rng);
-            if rhs == 0 {
-                continue;
-            }
-            let rhs_arbi = Arbi::from(rhs);
-            let expected_div = lhs as SQDigit / rhs as SQDigit;
-            let expected_rem = lhs as SQDigit % rhs as SQDigit;
-            assert_eq!(lhs / &rhs_arbi, expected_div);
-            assert_eq!(lhs % &rhs_arbi, expected_rem);
-            assert_eq!(lhs / rhs_arbi.clone(), expected_div);
-            assert_eq!(lhs % rhs_arbi, expected_rem);
+            test_div_rem_prim_lhs!(lhs, rhs);
 
             let rhs = die_sdigit.sample(&mut rng);
-            if rhs == 0 {
-                continue;
-            }
-            let rhs_arbi = Arbi::from(rhs);
-            let expected_div = lhs as SQDigit / rhs as SQDigit;
-            let expected_rem = lhs as SQDigit % rhs as SQDigit;
-            assert_eq!(lhs / &rhs_arbi, expected_div);
-            assert_eq!(lhs % &rhs_arbi, expected_rem);
-            assert_eq!(lhs / rhs_arbi.clone(), expected_div);
-            assert_eq!(lhs % rhs_arbi, expected_rem);
+            test_div_rem_prim_lhs!(lhs, rhs);
         }
     }
 }

--- a/arbi/src/division.rs
+++ b/arbi/src/division.rs
@@ -674,7 +674,7 @@ impl Div<&$signed_type> for Arbi {
 impl Div<$signed_type> for &Arbi {
     type Output = Arbi;
     fn div(self, other: $signed_type) -> Arbi {
-        self.clone() / Arbi::from(other)
+        self.clone() / other
     }
 }
 
@@ -715,7 +715,7 @@ impl Div<&Arbi> for &$signed_type {
 
 impl DivAssign<&$signed_type> for Arbi {
     fn div_assign(&mut self, other: &$signed_type) {
-        self.div_assign(*other);
+        (*self) /= *other;
     }
 }
 
@@ -817,7 +817,7 @@ impl Rem<&Arbi> for &$signed_type {
 
 impl RemAssign<&$signed_type> for Arbi {
     fn rem_assign(&mut self, other: &$signed_type) {
-        self.div_assign(*other);
+        (*self) %= *other;
     }
 }
 

--- a/arbi/src/division.rs
+++ b/arbi/src/division.rs
@@ -935,6 +935,57 @@ mod $test_module {
             assert_eq!(lhs_arbi % r, expected_rem);
         }
     }
+
+    #[test]
+    fn smoke_primitive_on_lhs() {
+        let (mut rng, _) = get_seedable_rng();
+        let die = get_uniform_die(<$signed_type>::MIN, <$signed_type>::MAX);
+        let die_sdigit = get_uniform_die(SDigit::MIN, SDigit::MAX);
+        let die_sddigit = get_uniform_die(SDDigit::MIN, SDDigit::MAX);
+        let die_sqdigit = get_uniform_die(SQDigit::MIN, SQDigit::MAX);
+        for _ in 0..i16::MAX {
+            let lhs = die.sample(&mut rng);
+            if !fits_in_i128(lhs) {
+                continue;
+            }
+
+            let rhs = die_sqdigit.sample(&mut rng);
+            if rhs == 0 {
+                continue;
+            }
+            let rhs_arbi = Arbi::from(rhs);
+            let expected_div = lhs as SQDigit / rhs as SQDigit;
+            let expected_rem = lhs as SQDigit % rhs as SQDigit;
+            assert_eq!(lhs / &rhs_arbi, expected_div);
+            assert_eq!(lhs % &rhs_arbi, expected_rem);
+            assert_eq!(lhs / rhs_arbi.clone(), expected_div);
+            assert_eq!(lhs % rhs_arbi, expected_rem);
+
+            let rhs = die_sddigit.sample(&mut rng);
+            if rhs == 0 {
+                continue;
+            }
+            let rhs_arbi = Arbi::from(rhs);
+            let expected_div = lhs as SQDigit / rhs as SQDigit;
+            let expected_rem = lhs as SQDigit % rhs as SQDigit;
+            assert_eq!(lhs / &rhs_arbi, expected_div);
+            assert_eq!(lhs % &rhs_arbi, expected_rem);
+            assert_eq!(lhs / rhs_arbi.clone(), expected_div);
+            assert_eq!(lhs % rhs_arbi, expected_rem);
+
+            let rhs = die_sdigit.sample(&mut rng);
+            if rhs == 0 {
+                continue;
+            }
+            let rhs_arbi = Arbi::from(rhs);
+            let expected_div = lhs as SQDigit / rhs as SQDigit;
+            let expected_rem = lhs as SQDigit % rhs as SQDigit;
+            assert_eq!(lhs / &rhs_arbi, expected_div);
+            assert_eq!(lhs % &rhs_arbi, expected_rem);
+            assert_eq!(lhs / rhs_arbi.clone(), expected_div);
+            assert_eq!(lhs % rhs_arbi, expected_rem);
+        }
+    }
 }
 
         )*

--- a/arbi/src/division.rs
+++ b/arbi/src/division.rs
@@ -637,7 +637,7 @@ mod test_divrem {
 
 /* !impl_arbi_div_for_primitive */
 macro_rules! impl_arbi_div_for_primitive {
-    ($(($signed_type:ty, $test_module:ident)),* ) => {
+    ($(($signed_type:ty, $test_module:ident)),*) => {
         $(
 
 impl Div<$signed_type> for Arbi {

--- a/arbi/src/division.rs
+++ b/arbi/src/division.rs
@@ -685,34 +685,6 @@ impl Div<&$signed_type> for &Arbi {
     }
 }
 
-impl Div<Arbi> for $signed_type {
-    type Output = Arbi;
-    fn div(self, other: Arbi) -> Arbi {
-        self / &other
-    }
-}
-
-impl Div<&Arbi> for $signed_type {
-    type Output = Arbi;
-    fn div(self, other: &Arbi) -> Arbi {
-        Arbi::from(self) / other
-    }
-}
-
-impl Div<Arbi> for &$signed_type {
-    type Output = Arbi;
-    fn div(self, other: Arbi) -> Arbi {
-        (*self) / other
-    }
-}
-
-impl Div<&Arbi> for &$signed_type {
-    type Output = Arbi;
-    fn div(self, other: &Arbi) -> Arbi {
-        (*self) / other
-    }
-}
-
 impl DivAssign<&$signed_type> for Arbi {
     fn div_assign(&mut self, other: &$signed_type) {
         (*self) /= *other;
@@ -787,34 +759,6 @@ impl Rem<&$signed_type> for &Arbi {
     }
 }
 
-impl Rem<Arbi> for $signed_type {
-    type Output = Arbi;
-    fn rem(self, other: Arbi) -> Arbi {
-        self % &other
-    }
-}
-
-impl Rem<&Arbi> for $signed_type {
-    type Output = Arbi;
-    fn rem(self, other: &Arbi) -> Arbi {
-        Arbi::from(self) % other
-    }
-}
-
-impl Rem<Arbi> for &$signed_type {
-    type Output = Arbi;
-    fn rem(self, other: Arbi) -> Arbi {
-        (*self) % other
-    }
-}
-
-impl Rem<&Arbi> for &$signed_type {
-    type Output = Arbi;
-    fn rem(self, other: &Arbi) -> Arbi {
-        (*self) % other
-    }
-}
-
 impl RemAssign<&$signed_type> for Arbi {
     fn rem_assign(&mut self, other: &$signed_type) {
         (*self) %= *other;
@@ -841,6 +785,64 @@ impl RemAssign<$signed_type> for Arbi {
                 *self = rem;
             }
         }
+    }
+}
+
+impl Div<Arbi> for $signed_type {
+    type Output = Arbi;
+    fn div(self, other: Arbi) -> Self::Output {
+        self / &other
+    }
+}
+
+impl Div<&Arbi> for $signed_type {
+    type Output = Arbi;
+    fn div(self, other: &Arbi) -> Self::Output {
+        let num = Arbi::from(self);
+        num / other
+    }
+}
+
+impl Div<Arbi> for &$signed_type {
+    type Output = Arbi;
+    fn div(self, other: Arbi) -> Self::Output {
+        (*self) / other
+    }
+}
+
+impl Div<&Arbi> for &$signed_type {
+    type Output = Arbi;
+    fn div(self, other: &Arbi) -> Self::Output {
+        (*self) / other
+    }
+}
+
+impl Rem<Arbi> for $signed_type {
+    type Output = Arbi;
+    fn rem(self, other: Arbi) -> Self::Output {
+        self % &other
+    }
+}
+
+impl Rem<&Arbi> for $signed_type {
+    type Output = Arbi;
+    fn rem(self, other: &Arbi) -> Self::Output {
+        let num = Arbi::from(self);
+        num % other
+    }
+}
+
+impl Rem<Arbi> for &$signed_type {
+    type Output = Arbi;
+    fn rem(self, other: Arbi) -> Self::Output {
+        (*self) % other
+    }
+}
+
+impl Rem<&Arbi> for &$signed_type {
+    type Output = Arbi;
+    fn rem(self, other: &Arbi) -> Self::Output {
+        (*self) % other
     }
 }
 


### PR DESCRIPTION
Used to track the implementation of the remaining arithmetic operators between `Arbi` integers and primitive integers.