### PR TITLE
Use `zero()` instead of `default()` internally

### DIFF
--- a/arbi/src/add.rs
+++ b/arbi/src/add.rs
@@ -440,7 +440,7 @@ mod tests {
     fn test_add() {
         let a = Arbi::from(10);
         let b = Arbi::from(-5);
-        let zero = Arbi::default();
+        let zero = Arbi::zero();
 
         assert_eq!(&a + &b, 5);
         assert_eq!(&b + &a, 5);

--- a/arbi/src/from_integral.rs
+++ b/arbi/src/from_integral.rs
@@ -42,7 +42,7 @@ impl From<$signed> for Arbi {
         type UnsignedT = $unsigned;
 
         let mut uvalue: UnsignedT;
-        let mut x = Arbi::default();
+        let mut x = Arbi::zero();
         if value == 0 {
             return x;
         } else if value < 0 {

--- a/arbi/src/increment_decrement.rs
+++ b/arbi/src/increment_decrement.rs
@@ -176,7 +176,7 @@ mod tests {
 
     #[test]
     fn test_around_zero() {
-        let mut arbi = Arbi::default();
+        let mut arbi = Arbi::zero();
         arbi.incr();
         assert_eq!(arbi, 1);
 

--- a/arbi/src/multiplication.rs
+++ b/arbi/src/multiplication.rs
@@ -180,7 +180,7 @@ impl Mul<Arbi> for Arbi {
     type Output = Self;
 
     fn mul(self, rhs: Self) -> Self::Output {
-        let mut ret = Arbi::default();
+        let mut ret = Arbi::zero();
         Self::mul_(&mut ret, &self, &rhs);
         ret
     }
@@ -191,7 +191,7 @@ impl<'a> Mul<&'a Arbi> for Arbi {
     type Output = Self;
 
     fn mul(self, rhs: &'a Arbi) -> Self {
-        let mut ret = Arbi::default();
+        let mut ret = Arbi::zero();
         Self::mul_(&mut ret, &self, rhs);
         ret
     }
@@ -232,7 +232,7 @@ impl<'b> Mul<&'b Arbi> for &Arbi {
     type Output = Arbi;
 
     fn mul(self, rhs: &'b Arbi) -> Self::Output {
-        let mut ret = Arbi::default();
+        let mut ret = Arbi::zero();
         Arbi::mul_(&mut ret, self, rhs);
         ret
     }


### PR DESCRIPTION
`git grep -r "::default"` listed a number of places where `default()` is used. `zero()` is preferred over `default()` as `zero()` is a `const` function.