### PR TITLE
Optimize Karatsuba

### DIFF
--- a/arbi/Cargo.toml
+++ b/arbi/Cargo.toml
@@ -27,3 +27,6 @@ rand = { version = "0.8.5", features = ["std_rng"] }
 
 [package.metadata.docs.rs]
 rustdoc-args = ["--html-in-header", "./doc/header.html"]
+
+[features]
+nightly = [] # for nightly bench, dev only

--- a/arbi/src/add.rs
+++ b/arbi/src/add.rs
@@ -1198,3 +1198,34 @@ impl Arbi {
         self.neg = false;
     }
 }
+
+#[cfg(test)]
+mod test_add3_abs_assign {
+    use crate::util::test::{get_seedable_rng, get_uniform_die, Distribution};
+    use crate::{Arbi, DDigit, QDigit};
+
+    // sum >= Arbi::BASE
+    #[test]
+    fn test_sum_gt_arbi_base_branch() {
+        let mut s = Arbi::zero();
+        let a = 9368850493200048722_u64;
+        let b = 11334117686971261073_u64;
+        let c = 9795558189060012567_u64;
+        s.add3_abs_assign(&Arbi::from(a), &Arbi::from(b), &Arbi::from(c));
+        assert_eq!(s, (a as QDigit) + (b as QDigit) + (c as QDigit));
+    }
+
+    #[test]
+    fn smoke() {
+        let (mut rng, _) = get_seedable_rng();
+        let die = get_uniform_die(DDigit::MIN, DDigit::MAX);
+        let mut s = Arbi::zero();
+        for _ in 0..i16::MAX {
+            let a = die.sample(&mut rng);
+            let b = die.sample(&mut rng);
+            let c = die.sample(&mut rng);
+            s.add3_abs_assign(&Arbi::from(a), &Arbi::from(b), &Arbi::from(c));
+            assert_eq!(s, (a as QDigit) + (b as QDigit) + (c as QDigit));
+        }
+    }
+}

--- a/arbi/src/add.rs
+++ b/arbi/src/add.rs
@@ -1216,6 +1216,26 @@ mod test_add3_abs_assign {
     }
 
     #[test]
+    fn test_nonzero_carry_after_loop() {
+        let mut s = Arbi::zero();
+        let a = 17384971691622762845_u64;
+        let b = 13975311186207392826_u64;
+        let c = 12301324174353418444_u64;
+        s.add3_abs_assign(&Arbi::from(a), &Arbi::from(b), &Arbi::from(c));
+        assert_eq!(s, (a as QDigit) + (b as QDigit) + (c as QDigit));
+    }
+
+    #[test]
+    fn test_zero_carry_after_loop() {
+        let mut s = Arbi::zero();
+        let a = 1743738137480021943_u64;
+        let b = 1619148075948679532_u64;
+        let c = 2567961127114686782_u64;
+        s.add3_abs_assign(&Arbi::from(a), &Arbi::from(b), &Arbi::from(c));
+        assert_eq!(s, (a as QDigit) + (b as QDigit) + (c as QDigit));
+    }
+
+    #[test]
     fn smoke() {
         let (mut rng, _) = get_seedable_rng();
         let die = get_uniform_die(DDigit::MIN, DDigit::MAX);

--- a/arbi/src/add.rs
+++ b/arbi/src/add.rs
@@ -1170,10 +1170,34 @@ mod test_sub_with_integral {
 }
 
 impl Arbi {
+    //  A nonnegative integer with n digits in base-B >= 2 has maximum value
+    //  B^{n} - 1.
+    //  ==> integers a, b, c have maximum values B^{n_a} - 1, ..., B^{n_c} - 1.
+    //  ==>
+    //      a + b + c <= (B^{n_a} - 1) + (B^{n_b} - 1) + (B^{n_c} - 1)
+    //                 = B^{n_a} + B^{n_b} + B^{n_c} - 3
+    //  Define N = max{n_a, n_b, n_c} so that B^N >= B^{n_a}, B^{n_b}, B^{n_c}.
+    //  ==>
+    //      a + b + c <= B^{N} + B^{N} + B^{N} - 3
+    //                 = 3B^{N} - 3
+    //  We want to show that an N + 1 digit base-B integer can hold the sum:
+    //      3B^{N} - 3 <= B^{N + 1} - 1 = B x B^{N} - 1
+    //  <==>
+    //      -3 <= B x B^{N} - 1 - 3B^{N}
+    //  <==>
+    //      -3 <= (B - 3)B^{N} - 1
+    //  <==>
+    //      -2 <= (B - 3)B^{N}
+    //  But
+    //      B >= 2 ==> (B - 3) >= -1 ==> (B - 3)B^{N} >= -B^{N} >= -2
+    //      (for B >= 2).
+    //  Thus, B^{N + 1} - 1 is an upper bound for the sum a + b + c.
+    //  The maximum number of digits needed to represent a + b + c is therefore
+    //      N + 1 = max{n_a, n_b, n_c} + 1.
     /// \\( self = |a| + |b| + |c| \\).
     pub(crate) fn add3_abs_assign(&mut self, a: &Arbi, b: &Arbi, c: &Arbi) {
         let max_size = a.size().max(b.size()).max(c.size());
-        self.vec.resize(max_size + 1, 0);
+        self.vec.resize(max_size + 1, 0); // see proof above
         let mut carry: Digit = 0;
         for i in 0..max_size {
             let mut sum: DDigit = carry as DDigit;

--- a/arbi/src/lib.rs
+++ b/arbi/src/lib.rs
@@ -7,7 +7,10 @@ SPDX-License-Identifier: Apache-2.0 OR MIT
 #![forbid(unsafe_code)]
 #![warn(missing_docs)]
 #![no_std]
+#![cfg_attr(feature = "nightly", feature(test))]
 extern crate alloc;
+#[cfg(all(feature = "nightly", test))]
+extern crate test;
 
 #[allow(unused_imports)]
 use alloc::string::String;

--- a/arbi/src/multiplication.rs
+++ b/arbi/src/multiplication.rs
@@ -440,16 +440,63 @@ impl Arbi {
             u1.is_negative(),
             v1.is_negative(),
         );
-        c -= &a + &b; // c = (u1 + u0)(v1 + v0) - (u0v0 + u1v1)
+
+        // c -= &a + &b; // c = (u1 + u0)(v1 + v0) - (u0v0 + u1v1)
+        c -= &a;
+        c -= &b;
 
         a <<= 2 * n * Digit::BITS as usize;
         c <<= n * Digit::BITS as usize;
-        *w = &a + &c + &b; // w = (Arbi::BASE ** 2n) * a + (Arbi::BASE ** n) * c + b
+
+        // *w = &a + &c + &b; // w = (Arbi::BASE ** 2n) * a + (Arbi::BASE ** n) * c + b
+        w.add3_abs_assign(&a, &b, &c);
     }
 
     #[allow(dead_code)]
     fn mul_karatsuba(w: &mut Self, u: &Self, v: &Self) {
         Self::dmul_karatsuba(w, &u.vec, &v.vec);
+    }
+}
+
+#[cfg(all(feature = "nightly", test))]
+mod benches_karatsuba {
+    use test::Bencher;
+
+    use super::*;
+    use crate::util::test::{
+        get_seedable_rng, get_uniform_die, random_arbi, Distribution,
+    };
+
+    #[bench]
+    fn bench_karatsuba(b: &mut Bencher) {
+        let (mut rng, _) = get_seedable_rng();
+        let die = get_uniform_die(
+            Arbi::KARATSUBA_THRESHOLD,
+            Arbi::KARATSUBA_THRESHOLD * 4,
+        );
+        b.iter(|| {
+            let random_size = Digit::BITS as usize * die.sample(&mut rng);
+            let r_1 = random_arbi(random_size);
+            let r_2 = random_arbi(random_size);
+            let mut x_k = Arbi::zero();
+            Arbi::mul_karatsuba(&mut x_k, &r_1, &r_2);
+        });
+    }
+
+    #[bench]
+    fn bench_standard(b: &mut Bencher) {
+        let (mut rng, _) = get_seedable_rng();
+        let die = get_uniform_die(
+            Arbi::KARATSUBA_THRESHOLD,
+            Arbi::KARATSUBA_THRESHOLD * 4,
+        );
+        b.iter(|| {
+            let random_size = Digit::BITS as usize * die.sample(&mut rng);
+            let r_1 = random_arbi(random_size);
+            let r_2 = random_arbi(random_size);
+            let mut x_k = Arbi::zero();
+            Arbi::mul_standard(&mut x_k, &r_1, &r_2);
+        });
     }
 }
 

--- a/arbi/src/multiplication.rs
+++ b/arbi/src/multiplication.rs
@@ -507,7 +507,7 @@ mod karatsuba {
         get_seedable_rng, get_uniform_die, random_arbi, Distribution,
     };
 
-    // #[test]
+    #[test]
     fn test_karatsuba() {
         let (mut rng, _) = get_seedable_rng();
         let die = get_uniform_die(

--- a/arbi/src/multiplication.rs
+++ b/arbi/src/multiplication.rs
@@ -409,12 +409,10 @@ impl Arbi {
     // TODO: optimize
     fn dmul_karatsuba(w: &mut Self, u: &[Digit], v: &[Digit]) {
         let n: usize = core::cmp::min(u.len(), v.len()) >> 1;
-
         let (mut u0, mut u1, mut v0, mut v1) =
             (Arbi::zero(), Arbi::zero(), Arbi::zero(), Arbi::zero());
         Self::dbisect(u, &mut u0, &mut u1, n);
         Self::dbisect(v, &mut v0, &mut v1, n);
-
         let (mut a, mut b, mut c) = (Arbi::zero(), Arbi::zero(), Arbi::zero());
         Self::dmul_(
             &mut a,
@@ -430,7 +428,6 @@ impl Arbi {
             u0.is_negative(),
             v0.is_negative(),
         ); // b = u0 * v0
-
         u1 += u0;
         v1 += v0;
         Self::dmul_(
@@ -440,14 +437,10 @@ impl Arbi {
             u1.is_negative(),
             v1.is_negative(),
         );
-
         // c -= &a + &b; // c = (u1 + u0)(v1 + v0) - (u0v0 + u1v1)
-        c -= &a;
-        c -= &b;
-
+        c.sub_sum_of_abs_gt(&a, &b);
         a <<= 2 * n * Digit::BITS as usize;
         c <<= n * Digit::BITS as usize;
-
         // *w = &a + &c + &b; // w = (Arbi::BASE ** 2n) * a + (Arbi::BASE ** n) * c + b
         w.add3_abs_assign(&a, &b, &c);
     }

--- a/arbi/src/multiplication.rs
+++ b/arbi/src/multiplication.rs
@@ -507,7 +507,7 @@ mod karatsuba {
         get_seedable_rng, get_uniform_die, random_arbi, Distribution,
     };
 
-    #[test]
+    // #[test]
     fn test_karatsuba() {
         let (mut rng, _) = get_seedable_rng();
         let die = get_uniform_die(

--- a/arbi/src/multiplication.rs
+++ b/arbi/src/multiplication.rs
@@ -406,6 +406,7 @@ impl Arbi {
         Self::dbisect(&x.vec, lower, upper, n);
     }
 
+    // TODO: optimize
     fn dmul_karatsuba(w: &mut Self, u: &[Digit], v: &[Digit]) {
         let n: usize = core::cmp::min(u.len(), v.len()) >> 1;
 


### PR DESCRIPTION
The initial Karatsuba algorithm implementation was done with correctness in mind.

In this PR, we try to minimize the number of memory allocations for a more efficient Karatsuba.