### PR TITLE
Bump version to 0.4.1

### DIFF
--- a/arbi/Cargo.toml
+++ b/arbi/Cargo.toml
@@ -18,7 +18,7 @@ license = "Apache-2.0 OR MIT"
 name = "arbi"
 readme = "README.md"
 repository = "https://github.com/OTheDev/arbi"
-version = "0.4.0"
+version = "0.4.1"
 
 [dependencies]
 


### PR DESCRIPTION
* Make Karatsuba (multiplication) impl. more efficient (#48)
* Use zero() instead of default() internally (#47)