### PR TITLE
Add initial support for random number generation

### DIFF
--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -35,7 +35,7 @@ jobs:
         cargo install cargo-audit
 
     - name: clippy
-      run: cargo clippy -- -D warnings
+      run: cargo clippy --features "std,rand" -- -D warnings
 
     - name: rustfmt
       run: cargo fmt -- --check
@@ -59,4 +59,4 @@ jobs:
         rustup component add clippy
 
     - name: clippy
-      run: cargo clippy -- -D warnings
+      run: cargo clippy --features "std,rand" -- -D warnings

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,7 +32,7 @@ jobs:
 
     - name: Run tests
       run: |
-        cargo test --release
+        cargo test --release --features "std,rand"
 
         # # Run examples
         # for example in examples/*; do
@@ -60,5 +60,5 @@ jobs:
 
     - name: Run tests with Rust 1.65
       run: |
-        cargo test --release
+        cargo test --release --features "std,rand"
       shell: bash

--- a/arbi/.cargo/config.toml
+++ b/arbi/.cargo/config.toml
@@ -1,2 +1,5 @@
 [build]
-rustdocflags = [ "--html-in-header", "./arbi/doc/header.html" ]
+rustdocflags = [
+    "--cfg", "docsrs",
+    "--html-in-header", "./arbi/doc/header.html"
+]

--- a/arbi/Cargo.toml
+++ b/arbi/Cargo.toml
@@ -28,7 +28,9 @@ rand = { version = "0.8.5", optional = true }
 rand = { version = "0.8.5", features = ["std_rng"] }
 
 [package.metadata.docs.rs]
-rustdoc-args = ["--html-in-header", "./doc/header.html"]
+# RUSTDOCFLAGS="--html-in-header ./arbi/doc/header.html --cfg docsrs" cargo +nightly doc --no-deps --all-features
+rustdoc-args = ["--html-in-header", "./doc/header.html", "--cfg", "docsrs"]
+all-features = true
 
 [features]
 std = [] # for std::error::Error implementations only

--- a/arbi/Cargo.toml
+++ b/arbi/Cargo.toml
@@ -31,6 +31,6 @@ rand = { version = "0.8.5", features = ["std_rng"] }
 rustdoc-args = ["--html-in-header", "./doc/header.html"]
 
 [features]
-std = [] # for core::error::Error implementations only
+std = [] # for std::error::Error implementations only
 nightly = [] # for nightly bench, dev only
 rand = ["dep:rand"] # for random number generation

--- a/arbi/Cargo.toml
+++ b/arbi/Cargo.toml
@@ -6,7 +6,7 @@ categories = [
     "mathematics",
     "no-std",
 ]
-description = "Arbitrary precision integer."
+description = "Arbitrary Precision Integer"
 edition = "2021"
 keywords = [
     "arbitrary-precision",
@@ -22,6 +22,7 @@ version = "0.4.1"
 rust-version = "1.65"
 
 [dependencies]
+rand = { version = "0.8.5", optional = true }
 
 [dev-dependencies]
 rand = { version = "0.8.5", features = ["std_rng"] }
@@ -30,5 +31,6 @@ rand = { version = "0.8.5", features = ["std_rng"] }
 rustdoc-args = ["--html-in-header", "./doc/header.html"]
 
 [features]
-std = []
+std = [] # for core::error::Error implementations only
 nightly = [] # for nightly bench, dev only
+rand = ["dep:rand"] # for random number generation

--- a/arbi/README.md
+++ b/arbi/README.md
@@ -12,9 +12,10 @@
 
 ## Features
 
-- **No dependencies**.
+- **No dependencies** by default.
 
-  Empty dependencies section in `Cargo.toml`.
+  If you need to generate random arbitrary integers, enable the `rand` feature,
+  which depends on the [rand](https://docs.rs/rand/latest/rand/) crate.
 
 - **`no_std`**.
 

--- a/arbi/src/lib.rs
+++ b/arbi/src/lib.rs
@@ -50,6 +50,7 @@ mod multiplication;
 mod negate;
 mod new;
 mod print_internal;
+mod random;
 mod right_shift;
 mod sign;
 mod size;
@@ -67,6 +68,8 @@ pub use base::{Base, BaseError};
 pub use exponentiation::Pow; // No PowAssign implementations yet
 pub use fits::Fits;
 pub use from_string::ParseError;
+#[cfg(feature = "rand")]
+pub use random::RandomArbi;
 
 /// Unsigned integer type representing a base-[`Arbi::BASE`] digit.
 pub type Digit = u32;

--- a/arbi/src/lib.rs
+++ b/arbi/src/lib.rs
@@ -4,6 +4,7 @@ SPDX-License-Identifier: Apache-2.0 OR MIT
 */
 
 #![doc = include_str!("../README.md")]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 #![forbid(unsafe_code)]
 #![warn(missing_docs)]
 #![cfg_attr(not(feature = "std"), no_std)]
@@ -69,6 +70,7 @@ pub use exponentiation::Pow; // No PowAssign implementations yet
 pub use fits::Fits;
 pub use from_string::ParseError;
 #[cfg(feature = "rand")]
+#[cfg_attr(docsrs, doc(cfg(feature = "rand")))]
 pub use random::RandomArbi;
 
 /// Unsigned integer type representing a base-[`Arbi::BASE`] digit.

--- a/arbi/src/random.rs
+++ b/arbi/src/random.rs
@@ -154,4 +154,18 @@ mod tests {
         let upper_excl = Arbi::from(-1000);
         let _ = rng.gen_arbi_range(&lower_incl, &upper_excl);
     }
+
+    #[test]
+    #[should_panic(expected = "capacity overflow")]
+    fn test_gen_uarbi_bits_panics_if_max_bits_exceeded() {
+        let mut rng = StepRng::new(42, 1);
+        let _ = rng.gen_uarbi(Arbi::MAX_BITS + 1);
+    }
+
+    #[test]
+    #[should_panic(expected = "capacity overflow")]
+    fn test_gen_iarbi_bits_panics_if_max_bits_exceeded() {
+        let mut rng = StepRng::new(42, 1);
+        let _ = rng.gen_iarbi(Arbi::MAX_BITS + 1);
+    }
 }

--- a/arbi/src/random.rs
+++ b/arbi/src/random.rs
@@ -97,7 +97,7 @@ fn assign_random_uarbi<T: Rng + ?Sized>(
 /// Panics if `upper_excl` is zero.
 fn gen_uarbi_under<T: Rng + ?Sized>(rng: &mut T, upper_excl: &Arbi) -> Arbi {
     if upper_excl.is_zero() {
-        panic!("upper_excl must not be zero")
+        panic!("void range")
     }
     let bits = upper_excl.size_bits();
     let mut random_arbi = rng.gen_uarbi(bits);
@@ -113,7 +113,7 @@ mod tests {
     use rand::rngs::mock::StepRng;
 
     #[test]
-    #[should_panic(expected = "upper_excl must not be zero")]
+    #[should_panic(expected = "void range")]
     fn test_gen_uarbi_under_where_upper_is_zero() {
         let mut rng = StepRng::new(42, 0);
         let upper_excl = Arbi::zero();

--- a/arbi/src/random.rs
+++ b/arbi/src/random.rs
@@ -184,4 +184,18 @@ mod tests {
         let a = rng.gen_iarbi(0);
         assert_eq!(a, 0);
     }
+
+    #[test]
+    fn test_gen_arbi_range_is_zero_for_0_to_1() {
+        let mut rng = StepRng::new(42, 1);
+        let a = rng.gen_arbi_range(&Arbi::ZERO, &Arbi::from(1));
+        assert_eq!(a, 0);
+    }
+
+    #[test]
+    fn test_gen_uarbi_under_is_zero_for_1_upperbound() {
+        let mut rng = StepRng::new(42, 1);
+        let a = rng.gen_uarbi_under(&Arbi::from(1));
+        assert_eq!(a, 0);
+    }
 }

--- a/arbi/src/random.rs
+++ b/arbi/src/random.rs
@@ -63,16 +63,6 @@ impl<T: Rng + ?Sized> RandomArbi for T {
         // be 1/2^{bits} > 0.5/2^{bits}. Consequently, an adjustment is needed
         // to ensure zero is not more likely than each possible positive or
         // negative value.
-        // Commented out if using only RngCore
-        // loop {
-        //     let mut arbi = self.gen_uarbi(bits);
-        //     if !arbi.is_zero() {
-        //         arbi.neg = self.next_u32() % 2 == 0;
-        //         return arbi;
-        //     } else if self.next_u32() % 2 == 0 {
-        //         return arbi;
-        //     }
-        // }
         let mut arbi = self.gen_uarbi(bits);
         loop {
             if !arbi.is_zero() {
@@ -117,11 +107,6 @@ fn assign_random_uarbi<T: Rng + ?Sized>(
 ) {
     let n_digits_ = BitCount::div_ceil_(bits, Digit::BITS as BitCount);
     let n_digits: usize = n_digits_.try_into().unwrap_or(usize::MAX);
-    // Commented out if using only RngCore
-    // let mut vec = Vec::with_capacity(n_digits);
-    // for _ in 0..n_digits {
-    //     vec.push(self.next_u32());
-    // }
     arbi.vec.resize(n_digits, 0);
     rng.fill(&mut arbi.vec[..]);
     let remaining = bits % Digit::BITS as BitCount;

--- a/arbi/src/random.rs
+++ b/arbi/src/random.rs
@@ -89,3 +89,34 @@ fn assign_random_uarbi<T: Rng + ?Sized>(
     arbi.neg = false;
     arbi.trim();
 }
+
+#[allow(dead_code)]
+/// Return a random `Arbi` integer in [0, upper_excl).
+///
+/// # Panic
+/// Panics if `upper_excl` is zero.
+fn gen_uarbi_under<T: Rng + ?Sized>(rng: &mut T, upper_excl: &Arbi) -> Arbi {
+    if upper_excl.is_zero() {
+        panic!("empty range")
+    }
+    let bits = upper_excl.size_bits();
+    let mut random_arbi = rng.gen_uarbi(bits);
+    while upper_excl <= &random_arbi {
+        assign_random_uarbi(rng, &mut random_arbi, bits);
+    }
+    random_arbi
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rand::rngs::mock::StepRng;
+
+    #[test]
+    #[should_panic(expected = "empty range")]
+    fn test_gen_uarbi_under_where_upper_is_zero() {
+        let mut rng = StepRng::new(42, 0);
+        let upper_excl = Arbi::zero();
+        let _ = gen_uarbi_under(&mut rng, &upper_excl);
+    }
+}

--- a/arbi/src/random.rs
+++ b/arbi/src/random.rs
@@ -97,7 +97,7 @@ fn assign_random_uarbi<T: Rng + ?Sized>(
 /// Panics if `upper_excl` is zero.
 fn gen_uarbi_under<T: Rng + ?Sized>(rng: &mut T, upper_excl: &Arbi) -> Arbi {
     if upper_excl.is_zero() {
-        panic!("empty range")
+        panic!("upper_excl must not be zero")
     }
     let bits = upper_excl.size_bits();
     let mut random_arbi = rng.gen_uarbi(bits);
@@ -113,7 +113,7 @@ mod tests {
     use rand::rngs::mock::StepRng;
 
     #[test]
-    #[should_panic(expected = "empty range")]
+    #[should_panic(expected = "upper_excl must not be zero")]
     fn test_gen_uarbi_under_where_upper_is_zero() {
         let mut rng = StepRng::new(42, 0);
         let upper_excl = Arbi::zero();

--- a/arbi/src/random.rs
+++ b/arbi/src/random.rs
@@ -1,0 +1,83 @@
+/*
+Copyright 2024 Owain Davies
+SPDX-License-Identifier: Apache-2.0 OR MIT
+*/
+
+#![cfg(feature = "rand")]
+
+use crate::uints::UnsignedUtilities;
+use crate::{Arbi, BitCount, Digit};
+use alloc::vec;
+use alloc::vec::Vec;
+use rand::Rng;
+
+/// Trait for generating random `Arbi` integers.
+pub trait RandomArbi {
+    /// Generate a random `Arbi` integer in the interval
+    /// \\( [0, 2^{\text{bits}} - 1] \\).
+    fn gen_uarbi(&mut self, bits: BitCount) -> Arbi;
+
+    /// Generate a random `Arbi` integer in the interval
+    /// \\( [-(2^{\text{bits}} - 1), \\; 2^{\text{bits}} - 1] \\).
+    fn gen_iarbi(&mut self, bits: BitCount) -> Arbi;
+}
+
+// https://docs.rs/rand/latest/rand/trait.Rng.html#generic-usage
+impl<T: Rng + ?Sized> RandomArbi for T {
+    fn gen_uarbi(&mut self, bits: BitCount) -> Arbi {
+        let n_digits_ = BitCount::div_ceil_(bits, Digit::BITS as BitCount);
+        let n_digits: usize = n_digits_.try_into().unwrap_or(usize::MAX);
+        // Commented out if using only RngCore
+        // let mut vec = Vec::with_capacity(n_digits);
+        // for _ in 0..n_digits {
+        //     vec.push(self.next_u32());
+        // }
+        let mut vec: Vec<Digit> = vec![0; n_digits];
+        self.fill(&mut vec[..]);
+        let remaining = bits % Digit::BITS as BitCount;
+        if remaining != 0 {
+            if let Some(last_digit) = vec.last_mut() {
+                let mask = Digit::MAX >> (Digit::BITS as BitCount - remaining);
+                *last_digit &= mask;
+            }
+        }
+        let neg = false;
+        let mut result = Arbi { vec, neg };
+        result.trim();
+        result
+    }
+
+    fn gen_iarbi(&mut self, bits: BitCount) -> Arbi {
+        // Suppose gen_uarbi(bits) gives each integer in [0, 2^{bits} - 1] a
+        // probability of 1/2^{bits}.
+        //
+        // If the integer is not zero, that is, it is positive, suppose we
+        // negate it with probability 0.5. Then the probability of an integer in
+        // [1, 2^{bits} - 1] is 0.5/2^{bits} and symmetrically, the probability
+        // of an integer in [-(2^{bits} - 1), -1] is 0.5/2^{bits}.
+        //
+        // If the integer is zero, without any adjustment, the probability would
+        // be 1/2^{bits} > 0.5/2^{bits}. Consequently, an adjustment is needed
+        // to ensure zero is not more likely than each possible positive or
+        // negative value.
+        // Commented out if using only RngCore
+        // loop {
+        //     let mut arbi = self.gen_uarbi(bits);
+        //     if !arbi.is_zero() {
+        //         arbi.neg = self.next_u32() % 2 == 0;
+        //         return arbi;
+        //     } else if self.next_u32() % 2 == 0 {
+        //         return arbi;
+        //     }
+        // }
+        loop {
+            let mut arbi = self.gen_uarbi(bits);
+            if !arbi.is_zero() {
+                arbi.neg = self.gen::<bool>();
+                return arbi;
+            } else if self.gen::<bool>() {
+                return arbi;
+            }
+        }
+    }
+}

--- a/arbi/src/random.rs
+++ b/arbi/src/random.rs
@@ -213,7 +213,7 @@ mod tests {
         let mut num_below = 0;
         for _ in 0..i16::MAX {
             let arbi = rng.gen_uarbi(192);
-            assert!(arbi >= Arbi::zero());
+            assert!(arbi >= 0);
             assert!(arbi.size_bits() <= 192);
             if arbi > mid {
                 num_above += 1;

--- a/arbi/src/random.rs
+++ b/arbi/src/random.rs
@@ -11,19 +11,27 @@ use rand::Rng;
 
 /// Trait for generating random `Arbi` integers.
 pub trait RandomArbi {
-    /// Generate a random `Arbi` integer in the interval
+    /// Generate a random `Arbi` integer in the closed interval
     /// \\( [0, 2^{\text{bits}} - 1] \\).
+    ///
+    /// # Panic
+    /// Panics if `Vec`'s maximum capacity is exceeded, i.e. `bits` exceeds
+    /// [`Arbi::MAX_BITS`] (or if the allocator reports allocation failure).
     fn gen_uarbi(&mut self, bits: BitCount) -> Arbi;
 
-    /// Generate a random `Arbi` integer in the interval
+    /// Generate a random `Arbi` integer in the closed interval
     /// \\( [-(2^{\text{bits}} - 1), \\; 2^{\text{bits}} - 1] \\).
+    ///
+    /// # Panic
+    /// Panics if `Vec`'s maximum capacity is exceeded, i.e. `bits` exceeds
+    /// [`Arbi::MAX_BITS`] (or if the allocator reports allocation failure).
     fn gen_iarbi(&mut self, bits: BitCount) -> Arbi;
 
     /// Generate a random `Arbi` integer in the half-open interval
     /// \\( [\text{lower_incl}, \\; \text{upper_excl})\\).
     ///
     /// # Panic
-    /// This function panics if `lower_incl >= upper_excl`.
+    /// Panics if `lower_incl >= upper_excl`.
     fn gen_arbi_range(&mut self, lower_incl: &Arbi, upper_excl: &Arbi) -> Arbi;
 }
 

--- a/arbi/src/random.rs
+++ b/arbi/src/random.rs
@@ -170,4 +170,18 @@ mod tests {
         let mut rng = StepRng::new(42, 1);
         let _ = rng.gen_iarbi(Arbi::MAX_BITS + 1);
     }
+
+    #[test]
+    fn test_gen_uarbi_is_zero_if_bits_is_zero() {
+        let mut rng = StepRng::new(42, 1);
+        let a = rng.gen_uarbi(0);
+        assert_eq!(a, 0);
+    }
+
+    #[test]
+    fn test_gen_iarbi_is_zero_if_bits_is_zero() {
+        let mut rng = StepRng::new(42, 1);
+        let a = rng.gen_iarbi(0);
+        assert_eq!(a, 0);
+    }
 }


### PR DESCRIPTION
In this PR, we add the `RandomArbi` trait, which can be used to generate random `Arbi` integers. Random integer generation is feature gated by the new feature `rand`, which depends on the `rand` crate.