### PR TITLE
Bump version to 0.5.0

### DIFF
--- a/arbi/Cargo.toml
+++ b/arbi/Cargo.toml
@@ -18,7 +18,7 @@ license = "Apache-2.0 OR MIT"
 name = "arbi"
 readme = "README.md"
 repository = "https://github.com/OTheDev/arbi"
-version = "0.4.1"
+version = "0.5.0"
 rust-version = "1.65"
 
 [dependencies]


### PR DESCRIPTION
* Added `RandomArbi` trait for random arbitrary integers. (#51)
* Set 1.65 as the minimum supported rust version. (#50)
* `std::error::Error` implementations for `ParseError` and `BaseError` are now gated by the `std` feature. no_std is the default. (#50)