### PR TITLE
Implement UniformSampler

### DIFF
--- a/arbi/src/random/mod.rs
+++ b/arbi/src/random/mod.rs
@@ -6,5 +6,6 @@ SPDX-License-Identifier: Apache-2.0 OR MIT
 #![cfg(feature = "rand")]
 
 mod random_arbi;
+mod uniform_sampler;
 
 pub use random_arbi::RandomArbi;

--- a/arbi/src/random/mod.rs
+++ b/arbi/src/random/mod.rs
@@ -1,0 +1,10 @@
+/*
+Copyright 2024 Owain Davies
+SPDX-License-Identifier: Apache-2.0 OR MIT
+*/
+
+#![cfg(feature = "rand")]
+
+mod random_arbi;
+
+pub use random_arbi::RandomArbi;

--- a/arbi/src/random/random_arbi.rs
+++ b/arbi/src/random/random_arbi.rs
@@ -3,8 +3,6 @@ Copyright 2024 Owain Davies
 SPDX-License-Identifier: Apache-2.0 OR MIT
 */
 
-#![cfg(feature = "rand")]
-
 use crate::uints::UnsignedUtilities;
 use crate::{Arbi, BitCount, Digit};
 use rand::Rng;

--- a/arbi/src/random/uniform_sampler.rs
+++ b/arbi/src/random/uniform_sampler.rs
@@ -1,0 +1,4 @@
+/*
+Copyright 2024 Owain Davies
+SPDX-License-Identifier: Apache-2.0 OR MIT
+*/

--- a/arbi/src/random/uniform_sampler.rs
+++ b/arbi/src/random/uniform_sampler.rs
@@ -2,3 +2,212 @@
 Copyright 2024 Owain Davies
 SPDX-License-Identifier: Apache-2.0 OR MIT
 */
+
+// See https://docs.rs/rand/0.8.5/rand/distributions/uniform/index.html#extending-uniform-to-support-a-custom-type
+
+use crate::{Arbi, RandomArbi};
+use rand::distributions::uniform::{
+    SampleBorrow, SampleUniform, UniformSampler,
+};
+use rand::Rng;
+
+#[derive(Debug, Clone)]
+pub struct UniformArbi {
+    // Instead of the following representation, we could store lo, hi instead.
+    // However, that approach leads to more memory allocations.
+    lower: Arbi,
+    delta: Arbi,
+}
+
+impl UniformSampler for UniformArbi {
+    type X = Arbi;
+
+    fn new<B1, B2>(lo_incl: B1, hi_excl: B2) -> Self
+    where
+        B1: SampleBorrow<Self::X> + Sized,
+        B2: SampleBorrow<Self::X> + Sized,
+    {
+        let lo_b: &Arbi = lo_incl.borrow();
+        let hi_b: &Arbi = hi_excl.borrow();
+        assert!(lo_b < hi_b);
+        UniformArbi {
+            lower: lo_b.clone(),
+            delta: hi_b - lo_b,
+        }
+    }
+
+    fn new_inclusive<B1, B2>(lo_incl: B1, hi_incl: B2) -> Self
+    where
+        B1: SampleBorrow<Self::X> + Sized,
+        B2: SampleBorrow<Self::X> + Sized,
+    {
+        let lo_b: &Arbi = lo_incl.borrow();
+        let hi_b: &Arbi = hi_incl.borrow();
+        assert!(lo_b <= hi_b);
+        let mut hi = hi_b.clone();
+        hi.incr();
+        UniformArbi {
+            lower: lo_b.clone(),
+            delta: hi - lo_b,
+        }
+    }
+
+    fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> Self::X {
+        &self.lower + rng.gen_uarbi_under(&self.delta)
+    }
+
+    fn sample_single<R: Rng + ?Sized, B1, B2>(
+        lo_incl: B1,
+        hi_excl: B2,
+        rng: &mut R,
+    ) -> Self::X
+    where
+        B1: SampleBorrow<Self::X> + Sized,
+        B2: SampleBorrow<Self::X> + Sized,
+    {
+        let lo: &Arbi = lo_incl.borrow();
+        let hi: &Arbi = hi_excl.borrow();
+        assert!(lo < hi);
+        rng.gen_arbi_range(lo, hi)
+    }
+}
+
+impl SampleUniform for Arbi {
+    type Sampler = UniformArbi;
+}
+
+#[cfg(test)]
+mod test_uniform_sampler {
+    use crate::{Arbi, DDigit, QDigit};
+    use rand::distributions::uniform::Uniform;
+    use rand::distributions::Distribution;
+    use rand::rngs::StdRng;
+    use rand::SeedableRng;
+
+    #[test]
+    #[should_panic]
+    fn test_new_panics_on_invalid_range() {
+        let (low, high) = (Arbi::from(DDigit::MAX), Arbi::from(DDigit::MAX));
+        let _ = Uniform::new(&low, &high);
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_new_inclusive_panics_on_invalid_range() {
+        let (low, high) = (
+            Arbi::from(DDigit::MAX as QDigit + 1),
+            Arbi::from(DDigit::MAX),
+        );
+        let _ = Uniform::new_inclusive(&low, &high);
+    }
+
+    #[test]
+    fn test_uniform_repeated() {
+        let mut rng = StdRng::seed_from_u64(42);
+        // -(2**256 - 1)
+        let lower = Arbi::from_str_radix(
+            "-ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+            16,
+        )
+        .unwrap();
+        // -(2**128 - 1)
+        let mut upper = Arbi::from(u128::MAX);
+        upper.negate_mut();
+        let mid = Arbi::from_str_radix(
+            "-800000000000000000000000000000007fffffffffffffffffffffffffffffff",
+            16,
+        )
+        .unwrap();
+        let uniform = Uniform::new(&lower, &upper);
+        let mut num_above = 0;
+        let mut num_below = 0;
+        for _ in 0..(i16::MAX >> 1) {
+            let arbi = uniform.sample(&mut rng);
+            assert!(arbi >= lower && arbi < upper);
+            if arbi > mid {
+                num_above += 1;
+            } else if arbi < mid {
+                num_below += 1;
+            }
+        }
+        let ratio = num_above as f64 / num_below as f64;
+        assert!(0.95 < ratio && ratio < 1.05);
+    }
+
+    #[test]
+    fn test_uniform_inclusive_repeated() {
+        let mut rng = StdRng::seed_from_u64(42);
+        // 2**128 - 1
+        let lower = Arbi::from(u128::MAX);
+        // 2**256 - 1
+        let upper = Arbi::from_str_radix(
+            "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+            16,
+        )
+        .unwrap();
+        let mid = Arbi::from_str_radix(
+            "800000000000000000000000000000007fffffffffffffffffffffffffffffff",
+            16,
+        )
+        .unwrap();
+        let uniform = Uniform::new_inclusive(&lower, &upper);
+        let mut num_above = 0;
+        let mut num_below = 0;
+        for _ in 0..(i16::MAX >> 1) {
+            let arbi = uniform.sample(&mut rng);
+            assert!(arbi >= lower && arbi < upper);
+            if arbi > mid {
+                num_above += 1;
+            } else if arbi < mid {
+                num_below += 1;
+            }
+        }
+        let ratio = num_above as f64 / num_below as f64;
+        assert!(0.95 < ratio && ratio < 1.05);
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_sample_single_panics_on_invalid_range() {
+        use rand::distributions::uniform::{SampleUniform, UniformSampler};
+        let mut rng = StdRng::seed_from_u64(42);
+        let (low, high) = (Arbi::from(DDigit::MAX), Arbi::from(DDigit::MAX));
+        let _ = <Arbi as SampleUniform>::Sampler::sample_single(
+            &low, &high, &mut rng,
+        );
+    }
+
+    #[test]
+    fn test_sample_single_repeated() {
+        use rand::distributions::uniform::{SampleUniform, UniformSampler};
+        let mut rng = StdRng::seed_from_u64(42);
+        // -(2**256 - 1)
+        let lower = Arbi::from_str_radix(
+            "-ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+            16,
+        )
+        .unwrap();
+        // 2**256 - 1
+        let upper = Arbi::from_str_radix(
+            "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+            16,
+        )
+        .unwrap();
+        let mid = 0;
+        let mut num_above = 0;
+        let mut num_below = 0;
+        for _ in 0..(i16::MAX >> 1) {
+            let arbi = <Arbi as SampleUniform>::Sampler::sample_single(
+                &lower, &upper, &mut rng,
+            );
+            assert!(arbi >= lower && arbi < upper);
+            if arbi > mid {
+                num_above += 1;
+            } else if arbi < mid {
+                num_below += 1;
+            }
+        }
+        let ratio = num_above as f64 / num_below as f64;
+        assert!(0.95 < ratio && ratio < 1.05);
+    }
+}

--- a/arbi/src/random/uniform_sampler.rs
+++ b/arbi/src/random/uniform_sampler.rs
@@ -13,7 +13,7 @@ use rand::Rng;
 
 #[derive(Debug, Clone)]
 pub struct UniformArbi {
-    // Instead of the following representation, we could store lo, hi instead.
+    // Instead of the following representation, we could just store lo, hi.
     // However, that approach leads to more memory allocations.
     lower: Arbi,
     delta: Arbi,


### PR DESCRIPTION
Used to track the implementation of the `rand:distributions::uniform::UniformSampler` trait.