### PR TITLE
Modify `set_bit()`, `test_bit()`, and co. to operate on two's complement representation

### DIFF
--- a/arbi/README.md
+++ b/arbi/README.md
@@ -254,20 +254,21 @@ extension).
 - Bitwise complement: `!`.
 - Bitwise AND, OR, and XOR: `&`, `|`, `^`, `&=`, `|=`, `^=`.
 
-Test or set a bit at a specified index (zero-based) on the absolute value of an
+Test, set, clear, or invert (i.e. toggle) a bit at a specified index on the
+two's complement representation (with sign extension) of an
 [`Arbi`](https://docs.rs/arbi/latest/arbi/struct.Arbi.html) integer:
 - [`Arbi::test_bit()`](https://docs.rs/arbi/latest/arbi/struct.Arbi.html#method.test_bit)
 - [`Arbi::set_bit()`](https://docs.rs/arbi/latest/arbi/struct.Arbi.html#method.set_bit)
+- [`Arbi::clear_bit()`](https://docs.rs/arbi/latest/arbi/struct.Arbi.html#method.clear_bit)
+- [`Arbi::invert_bit()`](https://docs.rs/arbi/latest/arbi/struct.Arbi.html#method.invert_bit)
 
 Obtain the number of bits needed to represent the absolute value of an [`Arbi`](https://docs.rs/arbi/latest/arbi/struct.Arbi.html)
 integer using [`Arbi::size_bits()`](https://docs.rs/arbi/latest/arbi/struct.Arbi.html#method.size_bits):
 
 ```rust
 use arbi::Arbi;
-
 let mut a = Arbi::zero();
 assert_eq!(a.size_bits(), 0);
-
 a.incr(); // 1
 assert_eq!(a.size_bits(), 1);
 a.incr(); // 10

--- a/arbi/src/bits.rs
+++ b/arbi/src/bits.rs
@@ -150,9 +150,8 @@ impl Arbi {
                 Ordering::Less => false,
                 Ordering::Equal => true,
                 Ordering::Greater => {
-                    !(((self.vec[digit_idx] >> (i % Digit::BITS as BitCount))
-                        & 1)
-                        != 0)
+                    ((self.vec[digit_idx] >> (i % Digit::BITS as BitCount)) & 1)
+                        == 0
                 }
             }
         }

--- a/arbi/src/bits.rs
+++ b/arbi/src/bits.rs
@@ -615,4 +615,105 @@ mod tests {
             check_set_bit(-79104890842846643010291851066536361984, 33);
         }
     }
+
+    #[cfg(test)]
+    mod spec_invert_bit {
+        use super::*;
+
+        fn check_invert_bit(v: i128, i: u32) {
+            let mut a = Arbi::from(v);
+            a.invert_bit(i as BitCount);
+            assert_eq!(a, invert_i128_bit(v, i));
+        }
+
+        #[test]
+        fn test_invert_bit_nonnegative_digit_idx_gte_size() {
+            check_invert_bit(3169162174, 35);
+            check_invert_bit(5297922818921732749, 64);
+        }
+
+        #[test]
+        fn test_invert_bit_nonnegative_digit_idx_lt_size() {
+            check_invert_bit(3220136555740037207, 0);
+            check_invert_bit(9577613604812561155, 35);
+        }
+
+        // TODO: for now, negative cases can be covered by the tests for test,
+        // set, and clear bit as invert bit is currently implemented in
+        // terms of them.
+    }
+
+    #[cfg(test)]
+    mod spec_clear_bit {
+        use super::*;
+
+        fn check_clear_bit(v: i128, i: u32) {
+            let mut a = Arbi::from(v);
+            a.clear_bit(i as BitCount);
+            assert_eq!(a, clear_i128_bit(v, i));
+        }
+
+        #[test]
+        fn test_clear_bit_nonnegative_digit_idx_lt_size() {
+            check_clear_bit(8165514632630324252, 35);
+            check_clear_bit(4207883224, 0);
+            check_clear_bit(1983355790, 1);
+        }
+
+        #[test]
+        fn test_clear_bit_nonnegative_digit_idx_gte_size() {
+            check_clear_bit(4227601892, 32);
+            check_clear_bit(1656726456, 33);
+        }
+
+        #[test]
+        fn test_clear_bit_negative_digit_idx_gte_size() {
+            check_clear_bit(-1312369833, 33);
+            check_clear_bit(-2064297443, 32);
+            check_clear_bit(-1131893546, 66);
+            check_clear_bit(-8608514187077909673, 66);
+        }
+
+        #[test]
+        fn test_clear_bit_negative_ordering_less() {
+            check_clear_bit(-18965961268936630417225958052012752896, 66);
+            check_clear_bit(-121952855773553855296845216926711967744, 11);
+        }
+
+        #[test]
+        fn test_clear_bit_negative_ordering_greater() {
+            check_clear_bit(-1264686768109554377, 11);
+            check_clear_bit(-5329284535033871352930409852495790005, 34);
+        }
+
+        #[test]
+        fn test_clear_bit_negative_ordering_equal() {
+            // No carry propagation
+            check_clear_bit(-143140054817892714756379615631696199680, 64);
+            check_clear_bit(-42682086721719978017573039099164491776, 32);
+            check_clear_bit(-7101851680573794725778516826707998950, 1);
+            check_clear_bit(-0b11110000000000000000000000000000000000000, 37);
+
+            // TODO: Generally speaking, the randomized testing above touches
+            // all code branches. More specific randomized testing for this
+            // branch should probably be added, as these had to be specially
+            // contrived.
+            // With carry propagation (twice)
+            check_clear_bit(-0b11111111111111111111111111111111, 0);
+            check_clear_bit(-0b11111111111111111111111111111110, 1);
+            check_clear_bit(-0b11111111111111111111111111111100, 2);
+            check_clear_bit(-0b11111111111111111111111111111000, 3);
+            check_clear_bit(-0b11111111111111111111111111110000, 4);
+            check_clear_bit(-0b11111111111111111111111111100000, 5);
+
+            // With carry propagation (once)
+            check_clear_bit(-0b111111111111111111111111111111111111111111111111111111111111111111111110, 1);
+            check_clear_bit(-0b111111111111111111111111111111111111111111111111111111111111111111111100, 2);
+            check_clear_bit(-0b111111111111111111111111111111111111111111111111111111111111111111111000, 3);
+            check_clear_bit(-0b111111111111111111111111111111111111111111111111111111111111111111110000, 4);
+            check_clear_bit(-0b111111111111111111111111111111111111111111111111111111111111111111100000, 5);
+            check_clear_bit(-0b111111111111111110000000000000000000000000000000000000000000000000000000, 55);
+            check_clear_bit(-0b111111111111111100000000000000000000000000000000000000000000000000000000, 56);
+        }
+    }
 }

--- a/arbi/src/bits.rs
+++ b/arbi/src/bits.rs
@@ -1,5 +1,5 @@
 /*
-Copyright 2024 Owain Davies
+Copyright 2024-2025 Owain Davies
 SPDX-License-Identifier: Apache-2.0 OR MIT
 */
 
@@ -333,7 +333,7 @@ impl Arbi {
 }
 
 #[cfg(test)]
-mod tests {
+mod tests_random {
     use super::*;
     use crate::util::test::{get_seedable_rng, get_uniform_die, Distribution};
     use crate::{BitCount, DDigit, Digit, QDigit, SDDigit, SDigit, SQDigit};
@@ -365,484 +365,49 @@ mod tests {
         v
     }
 
-    #[test]
-    fn test_clear_set_invert_bit_smoke() {
-        let (mut rng, _) = get_seedable_rng();
-        let die_digit = get_uniform_die(0, Digit::MAX);
-        let die_ddigit = get_uniform_die(Digit::MAX as DDigit + 1, DDigit::MAX);
-        let die_qdigit =
-            get_uniform_die(DDigit::MAX as QDigit + 1, QDigit::MAX);
-
-        for _ in 0..i16::MAX {
-            let mut r = die_digit.sample(&mut rng);
-            let mut a = Arbi::from(r);
-            let die = get_uniform_die(1, a.size_bits() - 1);
-            let i = die.sample(&mut rng);
-            a.clear_bit(i);
-            r &= !((1 as Digit) << i);
-            assert_eq!(a, r);
-            a.set_bit(i);
-            r |= (1 as Digit) << (i as BitCount);
-            assert_eq!(a, r);
-            a.invert_bit(i);
-            r ^= (1 as Digit) << (i as BitCount);
-            assert_eq!(a, r);
-
-            let mut r = die_ddigit.sample(&mut rng);
-            let mut a = Arbi::from(r);
-            let die = get_uniform_die(1, a.size_bits() - 1);
-            let i = die.sample(&mut rng);
-            a.clear_bit(i);
-            r &= !((1 as DDigit) << i);
-            assert_eq!(a, r);
-            a.set_bit(i);
-            r |= (1 as DDigit) << (i as BitCount);
-            assert_eq!(a, r);
-            a.invert_bit(i);
-            r ^= (1 as DDigit) << (i as BitCount);
-            assert_eq!(a, r);
-
-            let mut r = die_qdigit.sample(&mut rng);
-            let mut a = Arbi::from(r);
-            let die = get_uniform_die(1, a.size_bits() - 1);
-            let i = die.sample(&mut rng);
-            a.clear_bit(i);
-            r &= !((1 as QDigit) << i);
-            assert_eq!(a, r);
-            a.set_bit(i);
-            r |= (1 as QDigit) << (i as BitCount);
-            assert_eq!(a, r);
-            a.invert_bit(i);
-            r ^= (1 as QDigit) << (i as BitCount);
-            assert_eq!(a, r);
-        }
-    }
-
-    #[test]
-    fn test_clear_bit() {
-        assert_eq!(Arbi::zero().set_bit(0), 1);
-        assert_eq!(Arbi::from(10).set_bit(2), 14);
-
-        for i in 0..=53 {
-            let mut a = Arbi::from(2.0_f64.powi(i as i32));
-            a.clear_bit(i as BitCount);
-            assert_eq!(a, 0);
-        }
-    }
-
-    #[test]
-    fn test_set_and_test_bit() {
-        assert_eq!(Arbi::zero().set_bit(0), 1);
-        assert_eq!(Arbi::from(10).set_bit(2), 14);
-
-        for i in 0..=53 {
-            let mut a = Arbi::zero();
-            a.set_bit(i as BitCount);
-            assert_eq!(a, (2.0_f64.powi(i as i32)));
-            assert!(a.test_bit(i as BitCount));
-        }
-    }
-
-    #[test]
-    fn test_test_bit() {
-        // Zero
-        let x = Arbi::zero();
-        assert_eq!(x.test_bit(0), false);
-        assert_eq!(x.test_bit(42040), false);
-
-        // One
-        let x = Arbi::one();
-        assert_eq!(x.test_bit(0), true);
-        for i in 1..256 {
-            assert_eq!(x.test_bit(i), false);
-        }
-
-        // 1010 (MSB is the 1)
-        let x = Arbi::from(10);
-        assert_eq!(x.test_bit(0), false);
-        assert_eq!(x.test_bit(1), true);
-        assert_eq!(x.test_bit(2), false);
-        assert_eq!(x.test_bit(3), true);
-        for i in 4..256 {
-            assert_eq!(x.test_bit(i), false);
-        }
-
-        // Powers of Two
-        let mut one = Arbi::one();
-        one <<= 1_usize;
-        for i in 1..65000 {
-            assert_eq!(one.test_bit(i - 1), false);
-            assert_eq!(one.test_bit(i), true, "Failure at i = {}", i);
-            assert_eq!(one.test_bit(i + 1), false);
-            one <<= 1_usize;
-        }
-    }
-
-    #[test]
-    fn test_test_bit_negative_single_digit() {
-        // Negative one
-        let x = Arbi::neg_one();
-        for i in 0..256 {
-            assert_eq!(x.test_bit(i), true);
-        }
-
-        // 110
-        let x = Arbi::from(-2);
-        assert_eq!(x.test_bit(0), false);
-        assert_eq!(x.test_bit(1), true);
-        for i in 2..256 {
-            assert_eq!(x.test_bit(i), true);
-        }
-
-        // 101
-        let x = Arbi::from(-3);
-        assert_eq!(x.test_bit(0), true);
-        assert_eq!(x.test_bit(1), false);
-        for i in 2..256 {
-            assert_eq!(x.test_bit(i), true);
-        }
-
-        // 1011
-        let x = Arbi::from(-5);
-        assert_eq!(x.test_bit(0), true);
-        assert_eq!(x.test_bit(1), true);
-        assert_eq!(x.test_bit(2), false);
-        for i in 3..256 {
-            assert_eq!(x.test_bit(i), true);
-        }
-    }
-
-    #[test]
-    fn test_test_bit_negative_multiple_digits() {
-        // 10110010000011110000011100100110110000101111000100110001110110111
-        let v = -11232524694493961289_i128;
-        let x = Arbi::from(v);
-        for i in 0u32..128u32 {
-            assert_eq!(
-                x.test_bit(i as BitCount),
-                test_i128_bit(v, i),
-                "Failed for value {} at index {}",
-                v,
-                i
-            );
-        }
-    }
-
-    macro_rules! test_bit_value {
-        ($rng:expr, $die:expr) => {
-            let v = $die.sample(&mut $rng) as i128;
-            let x = Arbi::from(v);
-            for i in 0..i128::BITS {
-                assert_eq!(
-                    x.test_bit(i as BitCount),
-                    test_i128_bit(v, i),
-                    "Failed for value {} at index {}",
-                    v,
-                    i
-                );
-            }
-        };
-    }
-
-    #[test]
-    fn test_test_bit_negative_smoke() {
-        let (mut rng, _) = get_seedable_rng();
-        let die_sdigit = get_uniform_die(SDigit::MIN, SDigit::MAX);
-        let die_sddigit = get_uniform_die(SDDigit::MIN, SDDigit::MAX);
-        let die_sqdigit = get_uniform_die(SQDigit::MIN, SQDigit::MAX);
-        for _ in 0..i16::MAX {
-            test_bit_value!(rng, die_sdigit);
-            test_bit_value!(rng, die_sddigit);
-            test_bit_value!(rng, die_sqdigit);
-        }
-    }
-
-    macro_rules! test_arbi_variants_test {
-        ($die_digit:expr, $rng:expr, $( $vec:expr ),* ) => {
-            $(
-                let arbi = Arbi {
-                    vec: $vec,
-                    neg: true,
-                };
-                let v = match arbi.checked_to_i128() {
-                    Some(v) => v,
-                    None => continue,
-                };
-                for i in 0..(i128::BITS - 1) {
-                    let x = Arbi::from(v);
-                    assert_eq!(
-                        x.test_bit(i as BitCount),
-                        test_i128_bit(v, i),
-                        "Failed for value {} at index {}",
-                        v,
-                        i
-                    );
-                }
-            )*
-        };
-    }
-
-    #[test]
-    fn test_test_bit_branch() {
-        let arbi = Arbi {
-            vec: vec![0, 0, 583274041, 681312275],
-            neg: true,
-        };
-        let val = arbi.checked_to_i128().unwrap();
-        assert_eq!(val, -53979119657422662756390826147269574656_i128);
-        let idx = 32;
-        assert_eq!(arbi.test_bit(idx), test_i128_bit(val, idx as u32));
-
-        let (mut rng, _) = get_seedable_rng();
-        let die_digit = get_uniform_die(Digit::MIN, Digit::MAX);
-        for _ in 0..1000 {
-            test_arbi_variants_test!(
-                die_digit,
-                rng,
-                vec![
-                    0,
-                    die_digit.sample(&mut rng),
-                    die_digit.sample(&mut rng),
-                    die_digit.sample(&mut rng),
-                ],
-                vec![
-                    0,
-                    0,
-                    die_digit.sample(&mut rng),
-                    die_digit.sample(&mut rng),
-                ],
-                vec![0, 0, 0, die_digit.sample(&mut rng)]
-            );
-        }
-    }
-
-    macro_rules! test_set_bit_value {
+    macro_rules! test_bit_ops_for_type {
         ($rng:expr, $die:expr) => {
             let v = $die.sample(&mut $rng) as i128;
             for i in 0..(i128::BITS - 1) {
+                // Test
+                let x = Arbi::from(v);
+                assert_eq!(
+                    x.test_bit(i as BitCount),
+                    test_i128_bit(v, i),
+                    "test_bit failed for value {} at index {}",
+                    v,
+                    i
+                );
+
+                // Set
                 let mut x = Arbi::from(v);
                 x.set_bit(i as BitCount);
                 assert_eq!(
                     x,
                     set_i128_bit(v, i),
-                    "Failed for value {} at index {}",
+                    "set_bit failed for value {} at index {}",
                     v,
                     i
                 );
-            }
-        };
-    }
 
-    #[test]
-    fn test_set_bit_negative_smoke() {
-        let (mut rng, _) = get_seedable_rng();
-        let die_sdigit = get_uniform_die(SDigit::MIN, SDigit::MAX);
-        let die_sddigit = get_uniform_die(SDDigit::MIN, SDDigit::MAX);
-        let die_sqdigit = get_uniform_die(SQDigit::MIN, SQDigit::MAX);
-        for _ in 0..i16::MAX {
-            test_set_bit_value!(rng, die_sdigit);
-            test_set_bit_value!(rng, die_sddigit);
-            test_set_bit_value!(rng, die_sqdigit);
-        }
-    }
-
-    #[test]
-    fn test_set_bit_ordering_greater_branch() {
-        let val = -4866991881022244489_i128;
-        let mut arbi = Arbi::from(val);
-        let idx = 32;
-        assert_eq!(arbi.set_bit(idx), set_i128_bit(val, idx as u32));
-    }
-
-    #[test]
-    fn test_set_bit_ordering_equal_branch() {
-        let val = -1407405570_i128;
-        let mut arbi = Arbi::from(val);
-        let idx = 0;
-        assert_eq!(arbi.set_bit(idx), set_i128_bit(val, idx as u32));
-    }
-
-    macro_rules! test_arbi_variants {
-        ($die_digit:expr, $rng:expr, $( $vec:expr ),* ) => {
-            $(
-                let arbi = Arbi {
-                    vec: $vec,
-                    neg: true,
-                };
-                let v = match arbi.checked_to_i128() {
-                    Some(v) => v,
-                    None => continue,
-                };
-                for i in 0..(i128::BITS - 1) {
-                    let mut x = Arbi::from(v);
-                    x.set_bit(i as BitCount);
-                    assert_eq!(
-                        x,
-                        set_i128_bit(v, i),
-                        "Failed for value {} at index {}",
-                        v,
-                        i
-                    );
-                }
-            )*
-        };
-    }
-
-    #[test]
-    fn test_set_bit_ordering_less_branch() {
-        let mut arbi = Arbi {
-            vec: vec![0, 0, 583274041, 681312275],
-            neg: true,
-        };
-        let val = arbi.checked_to_i128().unwrap();
-        assert_eq!(val, -53979119657422662756390826147269574656_i128);
-        let idx = 32;
-        assert_eq!(arbi.set_bit(idx), set_i128_bit(val, idx as u32));
-
-        let (mut rng, _) = get_seedable_rng();
-        let die_digit = get_uniform_die(Digit::MIN, Digit::MAX);
-        for _ in 0..1000 {
-            test_arbi_variants!(
-                die_digit,
-                rng,
-                vec![
-                    0,
-                    die_digit.sample(&mut rng),
-                    die_digit.sample(&mut rng),
-                    die_digit.sample(&mut rng),
-                ],
-                vec![
-                    0,
-                    0,
-                    die_digit.sample(&mut rng),
-                    die_digit.sample(&mut rng),
-                ],
-                vec![0, 0, 0, die_digit.sample(&mut rng)]
-            );
-        }
-    }
-
-    macro_rules! test_clear_bit_value {
-        ($rng:expr, $die:expr) => {
-            let v = $die.sample(&mut $rng) as i128;
-            for i in 0..(i128::BITS - 1) {
+                // Clear
                 let mut x = Arbi::from(v);
                 x.clear_bit(i as BitCount);
                 assert_eq!(
                     x,
                     clear_i128_bit(v, i),
-                    "Failed for value {} at index {}",
+                    "clear_bit failed for value {} at index {}",
                     v,
                     i
                 );
-            }
-        };
-    }
 
-    #[test]
-    fn test_clear_bit_negative_smoke() {
-        let (mut rng, _) = get_seedable_rng();
-        let die_sdigit = get_uniform_die(SDigit::MIN, SDigit::MAX);
-        let die_sddigit = get_uniform_die(SDDigit::MIN, SDDigit::MAX);
-        let die_sqdigit = get_uniform_die(SQDigit::MIN, SQDigit::MAX);
-        for _ in 0..i16::MAX {
-            test_clear_bit_value!(rng, die_sdigit);
-            test_clear_bit_value!(rng, die_sddigit);
-            test_clear_bit_value!(rng, die_sqdigit);
-        }
-    }
-
-    macro_rules! test_arbi_variants_clear {
-        ($die_digit:expr, $rng:expr, $( $vec:expr ),* ) => {
-            $(
-                let arbi = Arbi {
-                    vec: $vec,
-                    neg: true,
-                };
-                let v = match arbi.checked_to_i128() {
-                    Some(v) => v,
-                    None => continue,
-                };
-                for i in 0..(i128::BITS - 1) {
-                    let mut x = Arbi::from(v);
-                    x.clear_bit(i as BitCount);
-                    assert_eq!(
-                        x,
-                        clear_i128_bit(v, i),
-                        "Failed for value {} at index {}",
-                        v,
-                        i
-                    );
-                }
-            )*
-        };
-    }
-
-    #[test]
-    fn test_clear_bit_branch() {
-        let mut arbi = Arbi {
-            vec: vec![0, 0, 583274041, 681312275],
-            neg: true,
-        };
-        let val = arbi.checked_to_i128().unwrap();
-        assert_eq!(val, -53979119657422662756390826147269574656_i128);
-        let idx = 32;
-        assert_eq!(arbi.clear_bit(idx), clear_i128_bit(val, idx as u32));
-
-        let (mut rng, _) = get_seedable_rng();
-        let die_digit = get_uniform_die(Digit::MIN, Digit::MAX);
-        for _ in 0..1000 {
-            test_arbi_variants_clear!(
-                die_digit,
-                rng,
-                vec![
-                    0,
-                    die_digit.sample(&mut rng),
-                    die_digit.sample(&mut rng),
-                    die_digit.sample(&mut rng),
-                ],
-                vec![
-                    0,
-                    0,
-                    die_digit.sample(&mut rng),
-                    die_digit.sample(&mut rng),
-                ],
-                vec![0, 0, 0, die_digit.sample(&mut rng)]
-            );
-        }
-    }
-
-    #[test]
-    fn test_clear_bit_b() {
-        // l
-        let val = -53979119657422662756390826147269574656_i128;
-        let mut arbi = Arbi::from(val);
-        let idx = 32;
-        assert_eq!(arbi.clear_bit(idx), clear_i128_bit(val, idx as u32));
-
-        // e
-        let val = -2123323316_i128;
-        let mut arbi = Arbi::from(val);
-        let idx = 0;
-        assert_eq!(arbi.clear_bit(idx), clear_i128_bit(val, idx as u32));
-
-        // g
-        let val = -4271208378563570_i128;
-        let mut arbi = Arbi::from(val);
-        let idx = 0;
-        assert_eq!(arbi.clear_bit(idx), clear_i128_bit(val, idx as u32));
-    }
-
-    macro_rules! test_invert_bit_value {
-        ($rng:expr, $die:expr) => {
-            let v = $die.sample(&mut $rng) as i128;
-            for i in 0..(i128::BITS - 1) {
+                // Invert
                 let mut x = Arbi::from(v);
                 x.invert_bit(i as BitCount);
                 assert_eq!(
                     x,
                     invert_i128_bit(v, i),
-                    "Failed for value {} at index {}",
+                    "invert_bit failed for value {} at index {}",
                     v,
                     i
                 );
@@ -851,36 +416,74 @@ mod tests {
     }
 
     #[test]
-    fn test_invert_bit_negative_smoke() {
+    fn test_bit_operations_smoke() {
         let (mut rng, _) = get_seedable_rng();
+        let die_digit = get_uniform_die(0, Digit::MAX);
+        let die_ddigit = get_uniform_die(Digit::MAX as DDigit + 1, DDigit::MAX);
+        let die_qdigit =
+            get_uniform_die(DDigit::MAX as QDigit + 1, QDigit::MAX);
         let die_sdigit = get_uniform_die(SDigit::MIN, SDigit::MAX);
         let die_sddigit = get_uniform_die(SDDigit::MIN, SDDigit::MAX);
         let die_sqdigit = get_uniform_die(SQDigit::MIN, SQDigit::MAX);
+
         for _ in 0..i16::MAX {
-            test_invert_bit_value!(rng, die_sdigit);
-            test_invert_bit_value!(rng, die_sddigit);
-            test_invert_bit_value!(rng, die_sqdigit);
+            test_bit_ops_for_type!(rng, die_digit);
+            test_bit_ops_for_type!(rng, die_ddigit);
+            test_bit_ops_for_type!(rng, die_qdigit);
+            test_bit_ops_for_type!(rng, die_sdigit);
+            test_bit_ops_for_type!(rng, die_sddigit);
+            test_bit_ops_for_type!(rng, die_sqdigit);
         }
     }
 
-    macro_rules! test_arbi_variants_invert {
-        ($die_digit:expr, $rng:expr, $( $vec:expr ),* ) => {
+    macro_rules! test_arbi_trailing_zeros_all_ops {
+        ($die_digit:expr, $rng:expr, $($vec:expr),* ) => {
             $(
-                let arbi = Arbi {
-                    vec: $vec,
-                    neg: true,
-                };
+                let arbi = Arbi::from_digits($vec, true);
                 let v = match arbi.checked_to_i128() {
                     Some(v) => v,
                     None => continue,
                 };
                 for i in 0..(i128::BITS - 1) {
+                    // Test
+                    let x = Arbi::from(v);
+                    assert_eq!(
+                        x.test_bit(i as BitCount),
+                        test_i128_bit(v, i),
+                        "test_bit failed for value {} at index {}",
+                        v,
+                        i
+                    );
+
+                    // Set
+                    let mut x = Arbi::from(v);
+                    x.set_bit(i as BitCount);
+                    assert_eq!(
+                        x,
+                        set_i128_bit(v, i),
+                        "set_bit failed for value {} at index {}",
+                        v,
+                        i
+                    );
+
+                    // Clear
+                    let mut x = Arbi::from(v);
+                    x.clear_bit(i as BitCount);
+                    assert_eq!(
+                        x,
+                        clear_i128_bit(v, i),
+                        "clear_bit failed for value {} at index {}",
+                        v,
+                        i
+                    );
+
+                    // Invert
                     let mut x = Arbi::from(v);
                     x.invert_bit(i as BitCount);
                     assert_eq!(
                         x,
                         invert_i128_bit(v, i),
-                        "Failed for value {} at index {}",
+                        "invert_bit failed for value {} at index {}",
                         v,
                         i
                     );
@@ -890,21 +493,11 @@ mod tests {
     }
 
     #[test]
-    fn test_invert_bit_branch() {
-        let mut arbi = Arbi {
-            vec: vec![0, 0, 583274041, 681312275],
-            neg: true,
-        };
-        let val = arbi.checked_to_i128().unwrap();
-        assert_eq!(arbi, val);
-        let idx = 32;
-        arbi.invert_bit(idx);
-        assert_eq!(arbi, invert_i128_bit(val, idx as u32));
-
+    fn test_arbi_trailing_zeros() {
         let (mut rng, _) = get_seedable_rng();
         let die_digit = get_uniform_die(Digit::MIN, Digit::MAX);
         for _ in 0..1000 {
-            test_arbi_variants_invert!(
+            test_arbi_trailing_zeros_all_ops!(
                 die_digit,
                 rng,
                 vec![

--- a/arbi/src/bits.rs
+++ b/arbi/src/bits.rs
@@ -534,25 +534,19 @@ mod tests {
 
         #[test]
         fn test_test_bit_size_lte_digit_idx_positive() {
-            // 1 digit
             check_test_bit(2794480102, 32);
-            // > 1 digit
             check_test_bit(3213823657745546596, 64);
         }
 
         #[test]
         fn test_test_bit_size_lte_digit_idx_negative() {
-            // 1 digit
             check_test_bit(-1094350350, 32);
-            // > 1 digit
             check_test_bit(-1445413578913102255, 64);
         }
 
         #[test]
         fn test_test_bit_size_gt_digit_idx_positive() {
-            // 1 digit
             check_test_bit(4142986110, 0);
-            // > 1 digit
             check_test_bit(12328930459554309820, 1);
         }
 
@@ -570,6 +564,55 @@ mod tests {
         fn test_test_bit_size_gt_digit_idx_negative_ordering_greater() {
             check_test_bit(-1630333990, 2);
             check_test_bit(-145885073049663941, 33);
+        }
+    }
+
+    #[cfg(test)]
+    mod spec_set_bit {
+        use super::*;
+
+        fn check_set_bit(v: i128, i: u32) {
+            let mut a = Arbi::from(v);
+            a.set_bit(i as BitCount);
+            assert_eq!(a, set_i128_bit(v, i));
+        }
+
+        #[test]
+        fn test_set_bit_nonnegative_digit_idx_gte_size() {
+            check_set_bit(231225232, 32);
+            check_set_bit(1117149505875380525, 64);
+        }
+
+        #[test]
+        fn test_set_bit_nonnegative_digit_idx_lt_size() {
+            check_set_bit(3624511275, 0);
+            check_set_bit(1731705162, 11);
+        }
+
+        #[test]
+        fn test_set_bit_negative_digit_idx_gte_size() {
+            check_set_bit(-5195882671383705216, 64);
+        }
+
+        #[test]
+        fn test_set_bit_negative_ordering_less() {
+            check_set_bit(-66142783587514876610185198462355676004, 0);
+            check_set_bit(-65062158611235322364225102006062153728, 0);
+            check_set_bit(-135942508526365600474330669961831251968, 32);
+            check_set_bit(-38035140290876007155503263883093606400, 64);
+            check_set_bit(-135942508526365600437437181814412148736, 32);
+            check_set_bit(-113029729128887551475283106339106062336, 35);
+        }
+
+        #[test]
+        fn test_set_bit_negative_ordering_greater() {
+            check_set_bit(-42118996697395892268090367623661261034, 2);
+        }
+
+        #[test]
+        fn test_set_bit_negative_ordering_equal() {
+            check_set_bit(-2131484967, 0);
+            check_set_bit(-79104890842846643010291851066536361984, 33);
         }
     }
 }

--- a/arbi/src/bits.rs
+++ b/arbi/src/bits.rs
@@ -3,128 +3,288 @@ Copyright 2024 Owain Davies
 SPDX-License-Identifier: Apache-2.0 OR MIT
 */
 
+//! Functions to test, set, clear, and toggle a bit at a specified index.
+//!
+//! Operates on the two's complement representation of an integer, with sign
+//! extension.
+
+// Consider magnitude A:
+//
+//           leftmost 0 is the (imaginary) sign bit
+//           |-------------------
+//                   1 is the first nonzero bit (f)
+//                   |-----------
+//                           rightmost bit is bit with index 0
+//                           |
+//      A = (0 bits  1 0 --- 0)_2
+//
+// -A is represented in two's complement (obtained by inverting bits in A and
+// adding 1) as:
+//
+//           leftmost 1 is the (imaginary) sign bit
+//           |----------------
+//                   1 is the first nonzero bit (f)
+//                   |--------
+//                           rightmost bit is bit with index 0
+//                           |
+//     -A = (1 ~bits 1 0 --- 0)_2
+//
+// Suppose we need to set (clear) bit j in -A, but we only store (A, sign). What
+// should the the bit representation of the new magnitude A' be and what's an
+// algorithm that will modify A to become A'?
+//
+// -----------------------------------------------------------------------------
+// Case 1: j < f
+// -----------------------------------------------------------------------------
+//  SET
+//      (-A)':
+//                           position j (around are all 0s)
+//                           |---------
+//          (1 ~bits 1 0 --- 1 --- 0)_2
+//      ~(-A)':
+//                           position j (around are all 1s)
+//                           |---------
+//          (0 bits  0 1 --- 0 --- 1)_2
+//      A' = ~(-A)' + 1:
+//                   position f (becomes 0)
+//                   |-----------------
+//                           position j (1s to left, 0s to right)
+//                           |---------
+//          (0 bits  0 1 --- 1 --- 0)_2
+//      A:
+//                   position f
+//                   |-----------------
+//                           position j
+//                           |---------
+//          (0 bits  1 0 --- 0 --- 0)_2
+//
+//      To get A' from A:
+//          (1) Clear bit f
+//          (2) Set bits [f - 1, j].
+//
+//  CLEAR
+//      A' = A  [It's already cleared, no change needed]
+//
+// -----------------------------------------------------------------------------
+// Case 2: j = f
+// -----------------------------------------------------------------------------
+//  SET
+//      A' = A  [It's already set, no change needed]
+//
+//  CLEAR
+//      -A:
+//                   position of f (first nonzero bit)
+//                   |-----------
+//          (1 ~bits 1 0 --- 0)_2
+//      (-A)':
+//          (1 ~bits 0 0 --- 0)_2   [Clear bit at position f]
+//      ~(-A)':
+//          (0 bits  1 1 --- 1)_2
+//      A' = ~(-A)' + 1:
+//          ([other] 0 0 --- 0)_2   [where other is bits + 1]
+//
+//      To get A' from A:
+//          (1) Clear bit f
+//          (2) Add 1 to bit field with indices > f: (f, inf).
+//
+// -----------------------------------------------------------------------------
+// Case 3: j > f
+// -----------------------------------------------------------------------------
+//  In -A, the relevant part is "~bits" which corresponds to "bits" in the
+//  magnitude.
+//
+//  SET
+//      Setting a bit in "~bits" is equivalent to clearing it in "bits". Thus
+//
+//      A' = A & ~(1 << j)
+//
+//  CLEAR
+//      Clearing a bit in "~bits" is equivalent to setting it in "bits". Thus
+//
+//      A' = A | (1 << j)
+
 use crate::{Arbi, BitCount, Digit};
+use core::cmp::Ordering;
 
 impl Arbi {
-    /// Test bit `i` (zero-based indexing) of the two's complement
-    /// representation of this integer (with sign extension).
+    fn first_nonzero_bit(&self) -> (usize, usize, BitCount) {
+        assert!(!self.is_zero());
+        let mut f_digit_idx = 0;
+        let mut f_bit_idx = 0;
+        for (idx, &digit) in self.vec.iter().enumerate() {
+            if digit != 0 {
+                f_digit_idx = idx;
+                f_bit_idx = digit.trailing_zeros() as BitCount;
+                break;
+            }
+        }
+        let f = (f_digit_idx as BitCount) * Digit::BITS as BitCount + f_bit_idx;
+        (f_digit_idx, f_bit_idx as usize, f)
+    }
+
+    /// Test bit `i` of the two's complement representation (with sign
+    /// extension) of this integer.
     ///
     /// # Examples
     /// ```
     /// use arbi::Arbi;
-    ///
     /// // 11000000111001 (bit indices [0, 13])
     /// let a = Arbi::from(12345);
     /// assert_eq!(a.test_bit(0), true);
     /// assert_eq!(a.test_bit(1), false);
     /// assert_eq!(a.test_bit(5), true);
     /// assert_eq!(a.test_bit(13), true);
-    ///
-    /// // 14 is not in [0, size_bits()). Bits outside of this range are
-    /// // treated as false.
+    /// // 14 is not in [0, size_bits()). Bits outside of this range (for
+    /// // nonnegative integers) are treated as false.
     /// assert_eq!(a.test_bit(14), false);
     /// ```
-    ///
-    /// # Complexity
-    /// - \\( O(1) \\) if nonnegative;
-    /// - \\( O(n) \\) otherwise.
     pub fn test_bit(&self, i: BitCount) -> bool {
-        let digit_idx: usize = (i / Digit::BITS as BitCount) as usize;
+        let digit_idx = (i / Digit::BITS as BitCount) as usize;
         if self.size() <= digit_idx {
             self.is_negative()
         } else {
-            let mut cur = self.vec[digit_idx];
+            let mut digit = self.vec[digit_idx];
             if self.is_negative() {
-                cur = (0 as Digit).wrapping_sub(cur);
-                for i in (0..(digit_idx + 1)).rev() {
-                    if i != 0 {
-                        cur = cur.wrapping_sub(1);
-                        break;
-                    }
+                digit = digit.wrapping_neg();
+                if self.vec[..digit_idx].iter().any(|&dig| dig != 0) {
+                    digit = digit.wrapping_sub(1);
                 }
             }
-            ((cur >> (i % Digit::BITS as BitCount)) & 1) != 0
+            ((digit >> (i % Digit::BITS as BitCount)) & 1) != 0
         }
     }
 
-    /// Set bit `i` (zero-based indexing) of the absolute value of this integer,
-    /// leaving its sign unchanged.
+    /// Set bit `i` of the two's complement representation (with sign extension)
+    /// of this integer.
     ///
     /// # Examples
     /// ```
     /// use arbi::Arbi;
-    ///
     /// // 11000000111001
     /// let mut a = Arbi::from(12345);
-    ///
     /// a.set_bit(1);
     /// // 11000000111011
     /// assert_eq!(a, 12347);
-    ///
     /// a.set_bit(14);
     /// // 111000000111011
     /// assert_eq!(a, 28731);
     /// ```
-    ///
-    /// # Complexity
-    /// - \\( O(1) \\) when setting an existing bit.
-    /// - \\( O(n) \\) when setting a bit outside the current bit width, as
-    ///     this requires resizing.
-    #[allow(clippy::unnecessary_cast)]
     pub fn set_bit(&mut self, i: BitCount) -> &mut Self {
-        let digit_idx: usize = (i / Digit::BITS as BitCount) as usize;
-        if digit_idx >= self.vec.len() {
-            self.vec.resize(digit_idx + 1, 0);
+        let digit_idx: usize = (i / Digit::BITS as BitCount)
+            .try_into()
+            .unwrap_or(usize::MAX);
+        let m = Digit::from(1u32) << (i % Digit::BITS as BitCount);
+        if !self.is_negative() {
+            if digit_idx >= self.size() {
+                self.vec.resize(digit_idx.saturating_add(1), 0);
+            }
+            self.vec[digit_idx] |= m;
+        } else {
+            if digit_idx >= self.size() {
+                // With sign extension, these bits are already set
+                return self;
+            }
+            let (f_digit_idx, f_bit_idx, f) = self.first_nonzero_bit();
+            match i.cmp(&f) {
+                Ordering::Less => {
+                    let f_mask = Digit::from(1u32) << f_bit_idx;
+                    // Clear bit f
+                    self.vec[f_digit_idx] &= !f_mask;
+                    // Set bits [f-1, j]
+                    if f_digit_idx == digit_idx {
+                        self.vec[digit_idx] |= (f_mask - 1) & !(m - 1);
+                    } else {
+                        self.vec[f_digit_idx] |= f_mask - 1;
+                        for idx in (digit_idx + 1)..f_digit_idx {
+                            self.vec[idx] = Digit::MAX;
+                        }
+                        self.vec[digit_idx] |= !(m - 1);
+                    }
+                }
+                Ordering::Equal => (),
+                Ordering::Greater => {
+                    self.vec[digit_idx] &= !m;
+                }
+            }
         }
-        self.vec[digit_idx] |= (1 as Digit) << (i % Digit::BITS as BitCount);
+        self.trim();
         self
     }
 
-    /// Clear bit `i` (zero-based indexing) of the absolute value of this
-    /// integer, leaving its sign unchanged (unless it becomes zero from a
-    /// negative `self`).
+    /// Clear bit `i` of the two's complement representation (with sign
+    /// extension) of this integer.
     ///
     /// # Examples
     /// ```
     /// use arbi::Arbi;
-    ///
-    /// // 11000000111001 (absolute value of -12345)
-    /// let mut a = Arbi::from(-12345);
-    ///
+    /// // 11000000111001
+    /// let mut a = Arbi::from(12345);
     /// a.clear_bit(0);
     /// // 11000000111000
-    /// assert_eq!(a, -12344);
-    ///
+    /// assert_eq!(a, 12344);
     /// a.clear_bit(13);
     /// // 1000000111000
-    /// assert_eq!(a, -4152);
-    ///
-    /// // Does nothing, as bits outside of the field defined by the indices
-    /// // [0, size_bits()) are treated as 0.
+    /// assert_eq!(a, 4152);
     /// a.clear_bit(13);
-    /// assert_eq!(a, -4152);
+    /// assert_eq!(a, 4152);
     /// ```
-    ///
-    /// # Complexity
-    /// \\( O(1) \\)
     pub fn clear_bit(&mut self, i: BitCount) -> &mut Self {
-        let n: usize = self.size();
-        let digit_idx: usize = (i / Digit::BITS as BitCount) as usize;
-        #[allow(clippy::unnecessary_cast)]
-        if digit_idx < n {
-            self.vec[digit_idx] &=
-                !((1 as Digit) << (i % Digit::BITS as BitCount));
-            self.trim();
+        let digit_idx: usize = (i / Digit::BITS as BitCount)
+            .try_into()
+            .unwrap_or(usize::MAX);
+        let m = Digit::from(1u32) << (i % Digit::BITS as BitCount);
+        if !self.is_negative() {
+            if digit_idx < self.size() {
+                // Clear bit
+                self.vec[digit_idx] &= !m;
+            } else {
+                /* Already clear */
+            }
+        } else if digit_idx >= self.size() {
+            self.vec.resize(digit_idx.saturating_add(1), 0);
+            self.vec[digit_idx] = m;
+        } else {
+            let (f_digit_idx, f_bit_idx, f) = self.first_nonzero_bit();
+            match i.cmp(&f) {
+                Ordering::Less => { /* Already clear */ }
+                Ordering::Equal => {
+                    // Clear bit f
+                    self.vec[f_digit_idx] &= !(Digit::from(1u32) << f_bit_idx);
+                    // For f's digit: add 1 only to bits more significant than f
+                    let high_m = !((Digit::from(1u32) << (f_bit_idx + 1)) - 1);
+                    let sum = (self.vec[f_digit_idx] & high_m)
+                        .wrapping_add(Digit::from(1u32) << (f_bit_idx + 1));
+                    let mut carry =
+                        (sum & high_m) < (self.vec[f_digit_idx] & high_m);
+                    self.vec[f_digit_idx] =
+                        (self.vec[f_digit_idx] & !high_m) | (sum & high_m);
+                    // Propagate carry if needed
+                    if carry {
+                        for digit in &mut self.vec[f_digit_idx + 1..] {
+                            let (new_digit, overflow) =
+                                digit.overflowing_add(1);
+                            *digit = new_digit;
+                            if !overflow {
+                                carry = false;
+                                break;
+                            }
+                        }
+                        if carry {
+                            self.vec.push(1);
+                        }
+                    }
+                }
+                Ordering::Greater => {
+                    self.vec[digit_idx] |= m;
+                }
+            }
         }
+        self.trim();
         self
     }
 
-    /// If the bit at zero-based index `i` of the absolute value of this integer
-    /// is `1`, clear it to `0`. Otherwise, set it to `1`.
-    ///
-    /// Please note that bits with indices outside of the range
-    /// `[0, size_bits())` are considered `0`. Thus, inverting a bit outside of
-    /// that range will set it to 1.
+    /// Toggle bit `i` of the two's complement representation (with sign
+    /// extension) of this integer.
     ///
     /// # Examples
     /// ```
@@ -135,19 +295,23 @@ impl Arbi {
     /// a.invert_bit(4); // 0b11110
     /// assert_eq!(a, 0b11110);
     /// ```
-    ///
-    /// # Complexity
-    /// - \\( O(1) \\) when inverting an existing bit (i.e. a bit with index in
-    ///     `[0, size_bits())`).
-    /// - \\( O(n) \\) otherwise.
-    #[allow(clippy::unnecessary_cast)]
     pub fn invert_bit(&mut self, i: BitCount) -> &mut Self {
-        let digit_idx: usize = (i / Digit::BITS as BitCount) as usize;
-        if digit_idx >= self.vec.len() {
-            self.vec.resize(digit_idx + 1, 0);
+        if !self.is_negative() {
+            let digit_idx: usize = (i / Digit::BITS as BitCount)
+                .try_into()
+                .unwrap_or(usize::MAX);
+            if digit_idx >= self.size() {
+                self.vec.resize(digit_idx.saturating_add(1), 0);
+            }
+            self.vec[digit_idx] ^=
+                Digit::from(1u32) << (i % Digit::BITS as BitCount);
+            self.trim();
+            self
+        } else if self.test_bit(i) {
+            self.clear_bit(i)
+        } else {
+            self.set_bit(i)
         }
-        self.vec[digit_idx] ^= (1 as Digit) << (i % Digit::BITS as BitCount);
-        self
     }
 }
 
@@ -155,12 +319,33 @@ impl Arbi {
 mod tests {
     use super::*;
     use crate::util::test::{get_seedable_rng, get_uniform_die, Distribution};
-    use crate::{BitCount, DDigit, QDigit, SDDigit, SDigit, SQDigit};
+    use crate::{BitCount, DDigit, Digit, QDigit, SDDigit, SDigit, SQDigit};
 
     fn test_i128_bit(v: i128, i: u32) -> bool {
         assert!(i < 128);
         let m = 1_i128 << i;
         (v & m) != 0
+    }
+
+    fn set_i128_bit(mut v: i128, i: u32) -> i128 {
+        assert!(i < 128);
+        let m = 1_i128 << i;
+        v |= m;
+        v
+    }
+
+    fn clear_i128_bit(mut v: i128, i: u32) -> i128 {
+        assert!(i < 128);
+        let m = 1_i128 << i;
+        v &= !m;
+        v
+    }
+
+    fn invert_i128_bit(mut v: i128, i: u32) -> i128 {
+        assert!(i < 128);
+        let m = 1_i128 << i;
+        v ^= m;
+        v
     }
 
     #[test]
@@ -352,6 +537,373 @@ mod tests {
             test_bit_value!(rng, die_sdigit);
             test_bit_value!(rng, die_sddigit);
             test_bit_value!(rng, die_sqdigit);
+        }
+    }
+
+    macro_rules! test_arbi_variants_test {
+        ($die_digit:expr, $rng:expr, $( $vec:expr ),* ) => {
+            $(
+                let arbi = Arbi {
+                    vec: $vec,
+                    neg: true,
+                };
+                let v = match arbi.checked_to_i128() {
+                    Some(v) => v,
+                    None => continue,
+                };
+                for i in 0..(i128::BITS - 1) {
+                    let x = Arbi::from(v);
+                    assert_eq!(
+                        x.test_bit(i as BitCount),
+                        test_i128_bit(v, i),
+                        "Failed for value {} at index {}",
+                        v,
+                        i
+                    );
+                }
+            )*
+        };
+    }
+
+    #[test]
+    fn test_test_bit_branch() {
+        let arbi = Arbi {
+            vec: vec![0, 0, 583274041, 681312275],
+            neg: true,
+        };
+        let val = arbi.checked_to_i128().unwrap();
+        assert_eq!(val, -53979119657422662756390826147269574656_i128);
+        let idx = 32;
+        assert_eq!(arbi.test_bit(idx), test_i128_bit(val, idx as u32));
+
+        let (mut rng, _) = get_seedable_rng();
+        let die_digit = get_uniform_die(Digit::MIN, Digit::MAX);
+        for _ in 0..1000 {
+            test_arbi_variants_test!(
+                die_digit,
+                rng,
+                vec![
+                    0,
+                    die_digit.sample(&mut rng),
+                    die_digit.sample(&mut rng),
+                    die_digit.sample(&mut rng),
+                ],
+                vec![
+                    0,
+                    0,
+                    die_digit.sample(&mut rng),
+                    die_digit.sample(&mut rng),
+                ],
+                vec![0, 0, 0, die_digit.sample(&mut rng)]
+            );
+        }
+    }
+
+    macro_rules! test_set_bit_value {
+        ($rng:expr, $die:expr) => {
+            let v = $die.sample(&mut $rng) as i128;
+            for i in 0..(i128::BITS - 1) {
+                let mut x = Arbi::from(v);
+                x.set_bit(i as BitCount);
+                assert_eq!(
+                    x,
+                    set_i128_bit(v, i),
+                    "Failed for value {} at index {}",
+                    v,
+                    i
+                );
+            }
+        };
+    }
+
+    #[test]
+    fn test_set_bit_negative_smoke() {
+        let (mut rng, _) = get_seedable_rng();
+        let die_sdigit = get_uniform_die(SDigit::MIN, SDigit::MAX);
+        let die_sddigit = get_uniform_die(SDDigit::MIN, SDDigit::MAX);
+        let die_sqdigit = get_uniform_die(SQDigit::MIN, SQDigit::MAX);
+        for _ in 0..i16::MAX {
+            test_set_bit_value!(rng, die_sdigit);
+            test_set_bit_value!(rng, die_sddigit);
+            test_set_bit_value!(rng, die_sqdigit);
+        }
+    }
+
+    #[test]
+    fn test_set_bit_ordering_greater_branch() {
+        let val = -4866991881022244489_i128;
+        let mut arbi = Arbi::from(val);
+        let idx = 32;
+        assert_eq!(arbi.set_bit(idx), set_i128_bit(val, idx as u32));
+    }
+
+    #[test]
+    fn test_set_bit_ordering_equal_branch() {
+        let val = -1407405570_i128;
+        let mut arbi = Arbi::from(val);
+        let idx = 0;
+        assert_eq!(arbi.set_bit(idx), set_i128_bit(val, idx as u32));
+    }
+
+    macro_rules! test_arbi_variants {
+        ($die_digit:expr, $rng:expr, $( $vec:expr ),* ) => {
+            $(
+                let arbi = Arbi {
+                    vec: $vec,
+                    neg: true,
+                };
+                let v = match arbi.checked_to_i128() {
+                    Some(v) => v,
+                    None => continue,
+                };
+                for i in 0..(i128::BITS - 1) {
+                    let mut x = Arbi::from(v);
+                    x.set_bit(i as BitCount);
+                    assert_eq!(
+                        x,
+                        set_i128_bit(v, i),
+                        "Failed for value {} at index {}",
+                        v,
+                        i
+                    );
+                }
+            )*
+        };
+    }
+
+    #[test]
+    fn test_set_bit_ordering_less_branch() {
+        let mut arbi = Arbi {
+            vec: vec![0, 0, 583274041, 681312275],
+            neg: true,
+        };
+        let val = arbi.checked_to_i128().unwrap();
+        assert_eq!(val, -53979119657422662756390826147269574656_i128);
+        let idx = 32;
+        assert_eq!(arbi.set_bit(idx), set_i128_bit(val, idx as u32));
+
+        let (mut rng, _) = get_seedable_rng();
+        let die_digit = get_uniform_die(Digit::MIN, Digit::MAX);
+        for _ in 0..1000 {
+            test_arbi_variants!(
+                die_digit,
+                rng,
+                vec![
+                    0,
+                    die_digit.sample(&mut rng),
+                    die_digit.sample(&mut rng),
+                    die_digit.sample(&mut rng),
+                ],
+                vec![
+                    0,
+                    0,
+                    die_digit.sample(&mut rng),
+                    die_digit.sample(&mut rng),
+                ],
+                vec![0, 0, 0, die_digit.sample(&mut rng)]
+            );
+        }
+    }
+
+    macro_rules! test_clear_bit_value {
+        ($rng:expr, $die:expr) => {
+            let v = $die.sample(&mut $rng) as i128;
+            for i in 0..(i128::BITS - 1) {
+                let mut x = Arbi::from(v);
+                x.clear_bit(i as BitCount);
+                assert_eq!(
+                    x,
+                    clear_i128_bit(v, i),
+                    "Failed for value {} at index {}",
+                    v,
+                    i
+                );
+            }
+        };
+    }
+
+    #[test]
+    fn test_clear_bit_negative_smoke() {
+        let (mut rng, _) = get_seedable_rng();
+        let die_sdigit = get_uniform_die(SDigit::MIN, SDigit::MAX);
+        let die_sddigit = get_uniform_die(SDDigit::MIN, SDDigit::MAX);
+        let die_sqdigit = get_uniform_die(SQDigit::MIN, SQDigit::MAX);
+        for _ in 0..i16::MAX {
+            test_clear_bit_value!(rng, die_sdigit);
+            test_clear_bit_value!(rng, die_sddigit);
+            test_clear_bit_value!(rng, die_sqdigit);
+        }
+    }
+
+    macro_rules! test_arbi_variants_clear {
+        ($die_digit:expr, $rng:expr, $( $vec:expr ),* ) => {
+            $(
+                let arbi = Arbi {
+                    vec: $vec,
+                    neg: true,
+                };
+                let v = match arbi.checked_to_i128() {
+                    Some(v) => v,
+                    None => continue,
+                };
+                for i in 0..(i128::BITS - 1) {
+                    let mut x = Arbi::from(v);
+                    x.clear_bit(i as BitCount);
+                    assert_eq!(
+                        x,
+                        clear_i128_bit(v, i),
+                        "Failed for value {} at index {}",
+                        v,
+                        i
+                    );
+                }
+            )*
+        };
+    }
+
+    #[test]
+    fn test_clear_bit_branch() {
+        let mut arbi = Arbi {
+            vec: vec![0, 0, 583274041, 681312275],
+            neg: true,
+        };
+        let val = arbi.checked_to_i128().unwrap();
+        assert_eq!(val, -53979119657422662756390826147269574656_i128);
+        let idx = 32;
+        assert_eq!(arbi.clear_bit(idx), clear_i128_bit(val, idx as u32));
+
+        let (mut rng, _) = get_seedable_rng();
+        let die_digit = get_uniform_die(Digit::MIN, Digit::MAX);
+        for _ in 0..1000 {
+            test_arbi_variants_clear!(
+                die_digit,
+                rng,
+                vec![
+                    0,
+                    die_digit.sample(&mut rng),
+                    die_digit.sample(&mut rng),
+                    die_digit.sample(&mut rng),
+                ],
+                vec![
+                    0,
+                    0,
+                    die_digit.sample(&mut rng),
+                    die_digit.sample(&mut rng),
+                ],
+                vec![0, 0, 0, die_digit.sample(&mut rng)]
+            );
+        }
+    }
+
+    #[test]
+    fn test_clear_bit_b() {
+        // l
+        let val = -53979119657422662756390826147269574656_i128;
+        let mut arbi = Arbi::from(val);
+        let idx = 32;
+        assert_eq!(arbi.clear_bit(idx), clear_i128_bit(val, idx as u32));
+
+        // e
+        let val = -2123323316_i128;
+        let mut arbi = Arbi::from(val);
+        let idx = 0;
+        assert_eq!(arbi.clear_bit(idx), clear_i128_bit(val, idx as u32));
+
+        // g
+        let val = -4271208378563570_i128;
+        let mut arbi = Arbi::from(val);
+        let idx = 0;
+        assert_eq!(arbi.clear_bit(idx), clear_i128_bit(val, idx as u32));
+    }
+
+    macro_rules! test_invert_bit_value {
+        ($rng:expr, $die:expr) => {
+            let v = $die.sample(&mut $rng) as i128;
+            for i in 0..(i128::BITS - 1) {
+                let mut x = Arbi::from(v);
+                x.invert_bit(i as BitCount);
+                assert_eq!(
+                    x,
+                    invert_i128_bit(v, i),
+                    "Failed for value {} at index {}",
+                    v,
+                    i
+                );
+            }
+        };
+    }
+
+    #[test]
+    fn test_invert_bit_negative_smoke() {
+        let (mut rng, _) = get_seedable_rng();
+        let die_sdigit = get_uniform_die(SDigit::MIN, SDigit::MAX);
+        let die_sddigit = get_uniform_die(SDDigit::MIN, SDDigit::MAX);
+        let die_sqdigit = get_uniform_die(SQDigit::MIN, SQDigit::MAX);
+        for _ in 0..i16::MAX {
+            test_invert_bit_value!(rng, die_sdigit);
+            test_invert_bit_value!(rng, die_sddigit);
+            test_invert_bit_value!(rng, die_sqdigit);
+        }
+    }
+
+    macro_rules! test_arbi_variants_invert {
+        ($die_digit:expr, $rng:expr, $( $vec:expr ),* ) => {
+            $(
+                let arbi = Arbi {
+                    vec: $vec,
+                    neg: true,
+                };
+                let v = match arbi.checked_to_i128() {
+                    Some(v) => v,
+                    None => continue,
+                };
+                for i in 0..(i128::BITS - 1) {
+                    let mut x = Arbi::from(v);
+                    x.invert_bit(i as BitCount);
+                    assert_eq!(
+                        x,
+                        invert_i128_bit(v, i),
+                        "Failed for value {} at index {}",
+                        v,
+                        i
+                    );
+                }
+            )*
+        };
+    }
+
+    #[test]
+    fn test_invert_bit_branch() {
+        let mut arbi = Arbi {
+            vec: vec![0, 0, 583274041, 681312275],
+            neg: true,
+        };
+        let val = arbi.checked_to_i128().unwrap();
+        assert_eq!(arbi, val);
+        let idx = 32;
+        arbi.invert_bit(idx);
+        assert_eq!(arbi, invert_i128_bit(val, idx as u32));
+
+        let (mut rng, _) = get_seedable_rng();
+        let die_digit = get_uniform_die(Digit::MIN, Digit::MAX);
+        for _ in 0..1000 {
+            test_arbi_variants_invert!(
+                die_digit,
+                rng,
+                vec![
+                    0,
+                    die_digit.sample(&mut rng),
+                    die_digit.sample(&mut rng),
+                    die_digit.sample(&mut rng),
+                ],
+                vec![
+                    0,
+                    0,
+                    die_digit.sample(&mut rng),
+                    die_digit.sample(&mut rng),
+                ],
+                vec![0, 0, 0, die_digit.sample(&mut rng)]
+            );
         }
     }
 }

--- a/arbi/src/bits.rs
+++ b/arbi/src/bits.rs
@@ -142,15 +142,19 @@ impl Arbi {
         let digit_idx = (i / Digit::BITS as BitCount) as usize;
         if self.size() <= digit_idx {
             self.is_negative()
+        } else if !self.is_negative() {
+            ((self.vec[digit_idx] >> (i % Digit::BITS as BitCount)) & 1) != 0
         } else {
-            let mut digit = self.vec[digit_idx];
-            if self.is_negative() {
-                digit = digit.wrapping_neg();
-                if self.vec[..digit_idx].iter().any(|&dig| dig != 0) {
-                    digit = digit.wrapping_sub(1);
+            let (_, _, f) = self.first_nonzero_bit();
+            match i.cmp(&f) {
+                Ordering::Less => false,
+                Ordering::Equal => true,
+                Ordering::Greater => {
+                    !(((self.vec[digit_idx] >> (i % Digit::BITS as BitCount))
+                        & 1)
+                        != 0)
                 }
             }
-            ((digit >> (i % Digit::BITS as BitCount)) & 1) != 0
         }
     }
 

--- a/arbi/src/bits.rs
+++ b/arbi/src/bits.rs
@@ -65,6 +65,9 @@ SPDX-License-Identifier: Apache-2.0 OR MIT
 //  CLEAR
 //      A' = A  [It's already cleared, no change needed]
 //
+//  INVERT
+//      Bit j is 0 ==> same as setting bit j.
+//
 // -----------------------------------------------------------------------------
 // Case 2: j = f
 // -----------------------------------------------------------------------------
@@ -87,6 +90,9 @@ SPDX-License-Identifier: Apache-2.0 OR MIT
 //          (1) Clear bit f
 //          (2) Add 1 to bit field with indices > f: (f, inf).
 //
+//  INVERT
+//      Bit j is 1 ==> same as clearing bit j.
+//
 // -----------------------------------------------------------------------------
 // Case 3: j > f
 // -----------------------------------------------------------------------------
@@ -102,6 +108,9 @@ SPDX-License-Identifier: Apache-2.0 OR MIT
 //      Clearing a bit in "~bits" is equivalent to setting it in "bits". Thus
 //
 //      A' = A | (1 << j)
+//
+// INVERT
+//      XOR. TODO.
 
 use crate::{Arbi, BitCount, Digit};
 use core::cmp::Ordering;
@@ -289,6 +298,7 @@ impl Arbi {
         self
     }
 
+    /* TODO: for the negative case, we can avoid using self.test_bit() */
     /// Toggle bit `i` of the two's complement representation (with sign
     /// extension) of this integer.
     ///

--- a/arbi/src/bits.rs
+++ b/arbi/src/bits.rs
@@ -333,9 +333,9 @@ impl Arbi {
 }
 
 #[cfg(test)]
-mod tests_random {
-    use super::*;
+mod tests {
     use crate::util::test::{get_seedable_rng, get_uniform_die, Distribution};
+    use crate::Arbi;
     use crate::{BitCount, DDigit, Digit, QDigit, SDDigit, SDigit, SQDigit};
 
     fn test_i128_bit(v: i128, i: u32) -> bool {
@@ -365,85 +365,13 @@ mod tests_random {
         v
     }
 
-    macro_rules! test_bit_ops_for_type {
-        ($rng:expr, $die:expr) => {
-            let v = $die.sample(&mut $rng) as i128;
-            for i in 0..(i128::BITS - 1) {
-                // Test
-                let x = Arbi::from(v);
-                assert_eq!(
-                    x.test_bit(i as BitCount),
-                    test_i128_bit(v, i),
-                    "test_bit failed for value {} at index {}",
-                    v,
-                    i
-                );
+    #[cfg(test)]
+    mod random {
+        use super::*;
 
-                // Set
-                let mut x = Arbi::from(v);
-                x.set_bit(i as BitCount);
-                assert_eq!(
-                    x,
-                    set_i128_bit(v, i),
-                    "set_bit failed for value {} at index {}",
-                    v,
-                    i
-                );
-
-                // Clear
-                let mut x = Arbi::from(v);
-                x.clear_bit(i as BitCount);
-                assert_eq!(
-                    x,
-                    clear_i128_bit(v, i),
-                    "clear_bit failed for value {} at index {}",
-                    v,
-                    i
-                );
-
-                // Invert
-                let mut x = Arbi::from(v);
-                x.invert_bit(i as BitCount);
-                assert_eq!(
-                    x,
-                    invert_i128_bit(v, i),
-                    "invert_bit failed for value {} at index {}",
-                    v,
-                    i
-                );
-            }
-        };
-    }
-
-    #[test]
-    fn test_bit_operations_smoke() {
-        let (mut rng, _) = get_seedable_rng();
-        let die_digit = get_uniform_die(0, Digit::MAX);
-        let die_ddigit = get_uniform_die(Digit::MAX as DDigit + 1, DDigit::MAX);
-        let die_qdigit =
-            get_uniform_die(DDigit::MAX as QDigit + 1, QDigit::MAX);
-        let die_sdigit = get_uniform_die(SDigit::MIN, SDigit::MAX);
-        let die_sddigit = get_uniform_die(SDDigit::MIN, SDDigit::MAX);
-        let die_sqdigit = get_uniform_die(SQDigit::MIN, SQDigit::MAX);
-
-        for _ in 0..i16::MAX {
-            test_bit_ops_for_type!(rng, die_digit);
-            test_bit_ops_for_type!(rng, die_ddigit);
-            test_bit_ops_for_type!(rng, die_qdigit);
-            test_bit_ops_for_type!(rng, die_sdigit);
-            test_bit_ops_for_type!(rng, die_sddigit);
-            test_bit_ops_for_type!(rng, die_sqdigit);
-        }
-    }
-
-    macro_rules! test_arbi_trailing_zeros_all_ops {
-        ($die_digit:expr, $rng:expr, $($vec:expr),* ) => {
-            $(
-                let arbi = Arbi::from_digits($vec, true);
-                let v = match arbi.checked_to_i128() {
-                    Some(v) => v,
-                    None => continue,
-                };
+        macro_rules! test_bit_ops_for_type {
+            ($rng:expr, $die:expr) => {
+                let v = $die.sample(&mut $rng) as i128;
                 for i in 0..(i128::BITS - 1) {
                     // Test
                     let x = Arbi::from(v);
@@ -488,32 +416,160 @@ mod tests_random {
                         i
                     );
                 }
-            )*
-        };
+            };
+        }
+
+        #[test]
+        fn test_bit_operations_smoke() {
+            let (mut rng, _) = get_seedable_rng();
+            let die_digit = get_uniform_die(0, Digit::MAX);
+            let die_ddigit =
+                get_uniform_die(Digit::MAX as DDigit + 1, DDigit::MAX);
+            let die_qdigit =
+                get_uniform_die(DDigit::MAX as QDigit + 1, QDigit::MAX);
+            let die_sdigit = get_uniform_die(SDigit::MIN, SDigit::MAX);
+            let die_sddigit = get_uniform_die(SDDigit::MIN, SDDigit::MAX);
+            let die_sqdigit = get_uniform_die(SQDigit::MIN, SQDigit::MAX);
+
+            for _ in 0..i16::MAX {
+                test_bit_ops_for_type!(rng, die_digit);
+                test_bit_ops_for_type!(rng, die_ddigit);
+                test_bit_ops_for_type!(rng, die_qdigit);
+                test_bit_ops_for_type!(rng, die_sdigit);
+                test_bit_ops_for_type!(rng, die_sddigit);
+                test_bit_ops_for_type!(rng, die_sqdigit);
+            }
+        }
+
+        macro_rules! test_arbi_trailing_zeros_all_ops {
+            ($die_digit:expr, $rng:expr, $($vec:expr),* ) => {
+                $(
+                    let arbi = Arbi::from_digits($vec, true);
+                    let v = match arbi.checked_to_i128() {
+                        Some(v) => v,
+                        None => continue,
+                    };
+                    for i in 0..(i128::BITS - 1) {
+                        // Test
+                        let x = Arbi::from(v);
+                        assert_eq!(
+                            x.test_bit(i as BitCount),
+                            test_i128_bit(v, i),
+                            "test_bit failed for value {} at index {}",
+                            v,
+                            i
+                        );
+
+                        // Set
+                        let mut x = Arbi::from(v);
+                        x.set_bit(i as BitCount);
+                        assert_eq!(
+                            x,
+                            set_i128_bit(v, i),
+                            "set_bit failed for value {} at index {}",
+                            v,
+                            i
+                        );
+
+                        // Clear
+                        let mut x = Arbi::from(v);
+                        x.clear_bit(i as BitCount);
+                        assert_eq!(
+                            x,
+                            clear_i128_bit(v, i),
+                            "clear_bit failed for value {} at index {}",
+                            v,
+                            i
+                        );
+
+                        // Invert
+                        let mut x = Arbi::from(v);
+                        x.invert_bit(i as BitCount);
+                        assert_eq!(
+                            x,
+                            invert_i128_bit(v, i),
+                            "invert_bit failed for value {} at index {}",
+                            v,
+                            i
+                        );
+                    }
+                )*
+            };
+        }
+
+        #[test]
+        fn test_arbi_trailing_zeros() {
+            let (mut rng, _) = get_seedable_rng();
+            let die_digit = get_uniform_die(Digit::MIN, Digit::MAX);
+            for _ in 0..1000 {
+                test_arbi_trailing_zeros_all_ops!(
+                    die_digit,
+                    rng,
+                    vec![
+                        0,
+                        die_digit.sample(&mut rng),
+                        die_digit.sample(&mut rng),
+                        die_digit.sample(&mut rng),
+                    ],
+                    vec![
+                        0,
+                        0,
+                        die_digit.sample(&mut rng),
+                        die_digit.sample(&mut rng),
+                    ],
+                    vec![0, 0, 0, die_digit.sample(&mut rng)]
+                );
+            }
+        }
     }
 
-    #[test]
-    fn test_arbi_trailing_zeros() {
-        let (mut rng, _) = get_seedable_rng();
-        let die_digit = get_uniform_die(Digit::MIN, Digit::MAX);
-        for _ in 0..1000 {
-            test_arbi_trailing_zeros_all_ops!(
-                die_digit,
-                rng,
-                vec![
-                    0,
-                    die_digit.sample(&mut rng),
-                    die_digit.sample(&mut rng),
-                    die_digit.sample(&mut rng),
-                ],
-                vec![
-                    0,
-                    0,
-                    die_digit.sample(&mut rng),
-                    die_digit.sample(&mut rng),
-                ],
-                vec![0, 0, 0, die_digit.sample(&mut rng)]
-            );
+    #[cfg(test)]
+    mod spec_test_bit {
+        use super::*;
+
+        fn check_test_bit(v: i128, i: u32) {
+            let a = Arbi::from(v);
+            assert_eq!(a.test_bit(i as BitCount), test_i128_bit(v, i));
+        }
+
+        #[test]
+        fn test_test_bit_size_lte_digit_idx_positive() {
+            // 1 digit
+            check_test_bit(2794480102, 32);
+            // > 1 digit
+            check_test_bit(3213823657745546596, 64);
+        }
+
+        #[test]
+        fn test_test_bit_size_lte_digit_idx_negative() {
+            // 1 digit
+            check_test_bit(-1094350350, 32);
+            // > 1 digit
+            check_test_bit(-1445413578913102255, 64);
+        }
+
+        #[test]
+        fn test_test_bit_size_gt_digit_idx_positive() {
+            // 1 digit
+            check_test_bit(4142986110, 0);
+            // > 1 digit
+            check_test_bit(12328930459554309820, 1);
+        }
+
+        #[test]
+        fn test_test_bit_size_gt_digit_idx_negative_ordering_less() {
+            check_test_bit(-8358488063644604456, 0);
+        }
+
+        #[test]
+        fn test_test_bit_size_gt_digit_idx_negative_ordering_equal() {
+            check_test_bit(-278205108, 2);
+        }
+
+        #[test]
+        fn test_test_bit_size_gt_digit_idx_negative_ordering_greater() {
+            check_test_bit(-1630333990, 2);
+            check_test_bit(-145885073049663941, 33);
         }
     }
 }

--- a/arbi/src/bits.rs
+++ b/arbi/src/bits.rs
@@ -173,6 +173,7 @@ impl Arbi {
         let digit_idx: usize = (i / Digit::BITS as BitCount)
             .try_into()
             .unwrap_or(usize::MAX);
+        #[allow(clippy::useless_conversion)]
         let m = Digit::from(1u32) << (i % Digit::BITS as BitCount);
         if !self.is_negative() {
             if digit_idx >= self.size() {
@@ -187,6 +188,7 @@ impl Arbi {
             let (f_digit_idx, f_bit_idx, f) = self.first_nonzero_bit();
             match i.cmp(&f) {
                 Ordering::Less => {
+                    #[allow(clippy::useless_conversion)]
                     let f_mask = Digit::from(1u32) << f_bit_idx;
                     // Clear bit f
                     self.vec[f_digit_idx] &= !f_mask;
@@ -228,6 +230,7 @@ impl Arbi {
     /// a.clear_bit(13);
     /// assert_eq!(a, 4152);
     /// ```
+    #[allow(clippy::useless_conversion)]
     pub fn clear_bit(&mut self, i: BitCount) -> &mut Self {
         let digit_idx: usize = (i / Digit::BITS as BitCount)
             .try_into()
@@ -300,11 +303,12 @@ impl Arbi {
             let digit_idx: usize = (i / Digit::BITS as BitCount)
                 .try_into()
                 .unwrap_or(usize::MAX);
+            #[allow(clippy::useless_conversion)]
+            let m = Digit::from(1u32) << (i % Digit::BITS as BitCount);
             if digit_idx >= self.size() {
                 self.vec.resize(digit_idx.saturating_add(1), 0);
             }
-            self.vec[digit_idx] ^=
-                Digit::from(1u32) << (i % Digit::BITS as BitCount);
+            self.vec[digit_idx] ^= m;
             self.trim();
             self
         } else if self.test_bit(i) {


### PR DESCRIPTION
Currently, `set_bit()`, `test_bit()`, `clear_bit()`, and `invert_bit()` operate only on the absolute value of the integer, leaving its sign unchanged. In this PR, they will be amended so that the two's complement representation of the `Arbi` integer is assumed, thereby changing their behavior for negative `Arbi` integers.

This is a **BREAKING** change.