### PR TITLE
CI: Remove installation of rustup as it is pre-installed

### DIFF
--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -23,7 +23,9 @@ jobs:
         rustup component add clippy rustfmt
         cargo install cargo-audit
     - run: cargo clippy --features "std,rand" -- -D warnings
-    - run: cargo +nightly fmt -- --check
+    - run: |
+        rustup toolchain install nightly
+        cargo +nightly fmt -- --check
     - run: cargo audit
 
   rust-1point65-clippy:

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -20,13 +20,15 @@ jobs:
     - uses: actions/checkout@v4
     - run: |
         rustup update stable && rustup override set stable
-        rustup component add clippy rustfmt
+        rustup component add clippy
         cargo install cargo-audit
     - run: cargo clippy --features "std,rand" -- -D warnings
-    - run: |
-        rustup toolchain install nightly
-        cargo +nightly fmt -- --check
     - run: cargo audit
+    - name: rustfmt (nightly)
+      run: |
+        rustup toolchain install nightly
+        rustup component add rustfmt --toolchain nightly
+        cargo +nightly fmt -- --check
 
   rust-1point65-clippy:
     runs-on: ubuntu-latest

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -6,57 +6,31 @@ on:
     paths:
       - 'arbi/**'
       - 'examples/**'
-
   pull_request:
     branches: [ main ]
     paths:
       - 'arbi/**'
       - 'examples/**'
-
   workflow_dispatch:
 
 jobs:
-  lint-and-audit:
+  rust-stable-clippy-fmt-audit:
     runs-on: ubuntu-latest
-
     steps:
     - uses: actions/checkout@v4
-
-    - name: Setup Rust Environment
-      run: |
-        # Install rustup
-        curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
-        . "$HOME/.cargo/env"
-
-        # Install clippy and rustfmt
+    - run: |
+        rustup update stable && rustup override set stable
         rustup component add clippy rustfmt
-
-        # Install cargo-audit
         cargo install cargo-audit
+    - run: cargo clippy --features "std,rand" -- -D warnings
+    - run: cargo +nightly fmt -- --check
+    - run: cargo audit
 
-    - name: clippy
-      run: cargo clippy --features "std,rand" -- -D warnings
-
-    - name: rustfmt
-      run: cargo fmt -- --check
-
-    - name: cargo-audit
-      run: cargo audit
-
-  clippy-rust-1point65:
+  rust-1point65-clippy:
     runs-on: ubuntu-latest
-
     steps:
     - uses: actions/checkout@v4
-
-    - name: Setup Rust Environment 1.65
-      run: |
-        rustup toolchain install 1.65.0
-        rustup default 1.65.0
-        . "$HOME/.cargo/env"
-
-        # Install clippy
+    - run: |
+        rustup toolchain install 1.65.0 && rustup override set 1.65.0
         rustup component add clippy
-
-    - name: clippy
-      run: cargo clippy --features "std,rand" -- -D warnings
+    - run: cargo clippy --features "std,rand" -- -D warnings

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -14,16 +14,15 @@ on:
   workflow_dispatch:
 
 jobs:
-  rust-stable-clippy-fmt-audit:
+  rust-stable-clippy-audit-fmt:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
-    - run: |
-        rustup update stable && rustup override set stable
-        rustup component add clippy
-        cargo install cargo-audit
+    - run: rustup update stable && rustup override set stable
     - run: cargo clippy --features "std,rand" -- -D warnings
-    - run: cargo audit
+    - run: |
+        cargo install cargo-audit
+        cargo audit
     - name: rustfmt (nightly)
       run: |
         rustup toolchain install nightly

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,59 +6,32 @@ on:
     paths:
       - 'arbi/**'
       - 'examples/**'
-
   pull_request:
     branches: [ main ]
     paths:
       - 'arbi/**'
       - 'examples/**'
-
   workflow_dispatch:
 
 jobs:
-  build-and-test:
+  rust-stable-build-and-test:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-
     steps:
     - uses: actions/checkout@v4
+    - run: rustup update stable && rustup override set stable
+    - run: cargo build --verbose
+    - run: cargo test --verbose --features "std,rand"
 
-    - name: Install Rust
-      run: |
-        curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
-      shell: bash
-
-    - name: Run tests
-      run: |
-        cargo test --release --features "std,rand"
-
-        # # Run examples
-        # for example in examples/*; do
-        #   if [ -f "$example/Cargo.toml" ]; then
-        #     cargo run --release --manifest-path "$example/Cargo.toml"
-        #   fi
-        # done
-      shell: bash
-
-  # Test MSRV
-  build-and-test-rust-1point65:
+  rust-1point65-build-and-test:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-
     steps:
     - uses: actions/checkout@v4
-
-    - name: Install Rust 1.65
-      run: |
-        rustup toolchain install 1.65.0
-        rustup default 1.65.0
-      shell: bash
-
-    - name: Run tests with Rust 1.65
-      run: |
-        cargo test --release --features "std,rand"
-      shell: bash
+    - run: rustup toolchain install 1.65.0 && rustup override set 1.65.0
+    - run: cargo build --verbose
+    - run: cargo test --verbose --features "std,rand"

--- a/arbi/Cargo.toml
+++ b/arbi/Cargo.toml
@@ -34,5 +34,5 @@ all-features = true
 
 [features]
 std = [] # for std::error::Error implementations only
-nightly = [] # for nightly bench, dev only
 rand = ["dep:rand"] # for random number generation
+nightly = [] # for nightly bench, dev only


### PR DESCRIPTION
GitHub hosted runners have rustup pre-installed.