### PR TITLE
Add `count_zeros()` method

### DIFF
--- a/arbi/src/builtin_int_methods/count_ones.rs
+++ b/arbi/src/builtin_int_methods/count_ones.rs
@@ -1,31 +1,42 @@
 /*
-Copyright 2024 Owain Davies
+Copyright 2024-2025 Owain Davies
 SPDX-License-Identifier: Apache-2.0 OR MIT
 */
 
-use crate::Arbi;
+use crate::{Arbi, BitCount};
 
 impl Arbi {
-    /// Returns the number of ones in the binary representation of the absolute
-    /// value of `self`.
+    /// If this integer is nonnegative, returns the number of ones in the binary
+    /// representation of `self`. Otherwise, returns `None`.
     ///
     /// # Examples
     /// ```
     /// use arbi::Arbi;
-    ///
-    /// let a = Arbi::from(0b01001100u32);
-    /// assert_eq!(a.count_ones(), 3);
-    ///
-    /// let max_u64 = Arbi::from(u64::MAX);
-    /// assert_eq!(max_u64.count_ones(), 64);
-    ///
-    /// let zero = Arbi::zero();
-    /// assert_eq!(zero.count_ones(), 0);
+    /// assert_eq!(Arbi::from(-1).count_ones(), None);
+    /// assert_eq!(Arbi::from(0).count_ones(), Some(0));
+    /// assert_eq!(Arbi::from(1).count_ones(), Some(1));
+    /// assert_eq!(Arbi::from(0b01001100u32).count_ones(), Some(3));
+    /// assert_eq!(Arbi::from(u64::MAX).count_ones(), Some(64));
     /// ```
     ///
-    /// ## Complexity
+    /// # Note
+    /// Theoretically, arbitrary precision (signed) integers have an unbounded
+    /// number of sign bits.
+    ///
+    /// Thus, this function returns `None` if the integer is negative.
+    ///
+    /// # Complexity
     /// \\( O(n) \\)
-    pub fn count_ones(&self) -> u128 {
+    pub fn count_ones(&self) -> Option<BitCount> {
+        if self.is_negative() {
+            None
+        } else {
+            Some(self.count_ones_abs())
+        }
+    }
+
+    #[inline]
+    pub(crate) fn count_ones_abs(&self) -> BitCount {
         self.vec.iter().map(|x| x.count_ones() as u128).sum()
     }
 }
@@ -34,10 +45,10 @@ impl Arbi {
 mod tests {
     use crate::util::test::{get_seedable_rng, get_uniform_die, Distribution};
     use crate::{Arbi, Assign};
-    use crate::{DDigit, Digit, QDigit};
+    use crate::{BitCount, DDigit, Digit, QDigit};
 
     #[test]
-    fn smoke() {
+    fn test_smoke() {
         let (mut rng, _) = get_seedable_rng();
         let die_d = get_uniform_die(Digit::MIN, Digit::MAX);
         let die_dd = get_uniform_die(Digit::MAX as DDigit + 1, DDigit::MAX);
@@ -45,41 +56,59 @@ mod tests {
         for _ in 0..i16::MAX {
             let digit = die_d.sample(&mut rng);
             let digit_arbi = Arbi::from(digit);
-            assert_eq!(digit_arbi.count_ones(), digit.count_ones() as u128);
+            assert_eq!(
+                digit_arbi.count_ones(),
+                Some(BitCount::from(digit.count_ones()))
+            );
 
             let ddigit = die_dd.sample(&mut rng);
             let ddigit_arbi = Arbi::from(ddigit);
-            assert_eq!(ddigit_arbi.count_ones(), ddigit.count_ones() as u128);
+            assert_eq!(
+                ddigit_arbi.count_ones(),
+                Some(BitCount::from(ddigit.count_ones()))
+            );
         }
     }
 
     #[test]
-    fn boundaries() {
+    fn test_special() {
         let zero = Arbi::zero();
-        assert_eq!(zero.count_ones(), 0_u32.count_ones() as u128);
+        assert_eq!(zero.count_ones(), Some(BitCount::from(0_u32.count_ones())));
 
         let mut a = Arbi::from(Digit::MAX - 1);
-        assert_eq!(a.count_ones(), (Digit::MAX - 1).count_ones() as u128);
+        assert_eq!(
+            a.count_ones(),
+            Some(BitCount::from((Digit::MAX - 1).count_ones()))
+        );
 
         a.assign(Digit::MAX);
-        assert_eq!(a.count_ones(), Digit::MAX.count_ones() as u128);
+        assert_eq!(
+            a.count_ones(),
+            Some(BitCount::from(Digit::MAX.count_ones()))
+        );
 
         a.incr();
         assert_eq!(
             a.count_ones(),
-            (Digit::MAX as DDigit + 1).count_ones() as u128
+            Some(BitCount::from((Digit::MAX as DDigit + 1).count_ones()))
         );
 
         a.assign(DDigit::MAX - 1);
-        assert_eq!(a.count_ones(), (DDigit::MAX - 1).count_ones() as u128);
+        assert_eq!(
+            a.count_ones(),
+            Some(BitCount::from((DDigit::MAX - 1).count_ones()))
+        );
 
         a.assign(DDigit::MAX);
-        assert_eq!(a.count_ones(), DDigit::MAX.count_ones() as u128);
+        assert_eq!(
+            a.count_ones(),
+            Some(BitCount::from(DDigit::MAX.count_ones() as u128))
+        );
 
         a.assign(DDigit::MAX as QDigit + 1);
         assert_eq!(
             a.count_ones(),
-            (DDigit::MAX as QDigit + 1).count_ones() as u128
+            Some(BitCount::from((DDigit::MAX as QDigit + 1).count_ones()))
         );
     }
 }

--- a/arbi/src/builtin_int_methods/count_zeros.rs
+++ b/arbi/src/builtin_int_methods/count_zeros.rs
@@ -45,33 +45,42 @@ impl Arbi {
 mod tests {
     use crate::util::test::{get_seedable_rng, get_uniform_die, Distribution};
     use crate::Arbi;
-    use crate::{BitCount, SDDigit, SDigit, SQDigit};
+    use crate::{BitCount, DDigit, Digit, QDigit, SDDigit, SDigit, SQDigit};
 
     macro_rules! assert_count_zeros {
         ($value:expr) => {
-            let value = $value;
-            assert_eq!(
-                Arbi::from(value).count_zeros(),
-                if value >= 0 {
-                    None
-                } else {
-                    Some(BitCount::from(value.count_zeros()))
-                }
-            );
+            #[allow(unused_comparisons)] // for unsigned types
+            {
+                let value = $value;
+                assert_eq!(
+                    Arbi::from(value).count_zeros(),
+                    if value >= 0 {
+                        None
+                    } else {
+                        Some(BitCount::from(value.count_zeros()))
+                    }
+                );
+            }
         };
     }
 
     #[test]
     fn test_smoke() {
         let (mut rng, _) = get_seedable_rng();
+        let die_d = get_uniform_die(Digit::MIN, Digit::MAX);
+        let die_dd = get_uniform_die(Digit::MAX as DDigit + 1, DDigit::MAX);
+        let die_qd = get_uniform_die(DDigit::MAX as QDigit + 1, QDigit::MAX);
         let die_sd = get_uniform_die(SDigit::MIN, SDigit::MAX);
-        let die_dd = get_uniform_die(SDDigit::MIN, SDDigit::MAX);
-        let die_qd = get_uniform_die(SQDigit::MIN, SQDigit::MAX);
+        let die_sdd = get_uniform_die(SDDigit::MIN, SDDigit::MAX);
+        let die_sqd = get_uniform_die(SQDigit::MIN, SQDigit::MAX);
 
         for _ in 0..i16::MAX {
-            assert_count_zeros!(die_sd.sample(&mut rng));
+            assert_count_zeros!(die_d.sample(&mut rng));
             assert_count_zeros!(die_dd.sample(&mut rng));
             assert_count_zeros!(die_qd.sample(&mut rng));
+            assert_count_zeros!(die_sd.sample(&mut rng));
+            assert_count_zeros!(die_sdd.sample(&mut rng));
+            assert_count_zeros!(die_sqd.sample(&mut rng));
         }
     }
 }

--- a/arbi/src/builtin_int_methods/count_zeros.rs
+++ b/arbi/src/builtin_int_methods/count_zeros.rs
@@ -1,0 +1,77 @@
+/*
+Copyright 2025 Owain Davies
+SPDX-License-Identifier: Apache-2.0 OR MIT
+*/
+
+use crate::{Arbi, BitCount};
+
+impl Arbi {
+    /// If this integer is negative, returns the number of zeros in its binary
+    /// representation (two's complement). Otherwise, returns `None`.
+    ///
+    /// # Examples
+    /// ```
+    /// use arbi::Arbi;
+    /// assert_eq!(Arbi::from(1).count_zeros(), None);
+    /// assert_eq!(Arbi::from(0).count_zeros(), None);
+    /// assert_eq!(Arbi::from(-1).count_zeros(), Some(0)); // 1111 1111
+    /// assert_eq!(Arbi::from(-2).count_zeros(), Some(1)); // 1111 1110
+    /// assert_eq!(Arbi::from(-128).count_zeros(), Some(7)); // 1000 0000
+    /// ```
+    ///
+    /// # Note
+    /// Theoretically, arbitrary precision (signed) integers have an unbounded
+    /// number of sign bits.
+    ///
+    /// Thus, this function returns `None` if the integer is nonnegative.
+    ///
+    /// If you need the number of zeros in the magnitude of the integer defined
+    /// by the bit field `[0, size_bits())`, use [`Arbi::count_ones()`] combined
+    /// with [`Arbi::size_bits()`].
+    ///
+    /// # Complexity
+    /// \\( O(n) \\)
+    pub fn count_zeros(&self) -> Option<BitCount> {
+        if self.is_negative() {
+            /* TODO: use single pass */
+            Some(self.trailing_zeros().unwrap() + self.count_ones_abs() - 1)
+        } else {
+            None
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::util::test::{get_seedable_rng, get_uniform_die, Distribution};
+    use crate::Arbi;
+    use crate::{BitCount, SDDigit, SDigit, SQDigit};
+
+    macro_rules! assert_count_zeros {
+        ($value:expr) => {
+            let value = $value;
+            assert_eq!(
+                Arbi::from(value).count_zeros(),
+                if value >= 0 {
+                    None
+                } else {
+                    Some(BitCount::from(value.count_zeros()))
+                }
+            );
+        };
+    }
+
+    #[test]
+    fn test_smoke() {
+        let (mut rng, _) = get_seedable_rng();
+        let die_sd = get_uniform_die(SDigit::MIN, SDigit::MAX);
+        let die_dd = get_uniform_die(SDDigit::MIN, SDDigit::MAX);
+        let die_qd = get_uniform_die(SQDigit::MIN, SQDigit::MAX);
+
+        for _ in 0..i16::MAX {
+            assert_count_zeros!(die_sd.sample(&mut rng));
+            assert_count_zeros!(die_dd.sample(&mut rng));
+            assert_count_zeros!(die_qd.sample(&mut rng));
+        }
+    }
+}

--- a/arbi/src/builtin_int_methods/mod.rs
+++ b/arbi/src/builtin_int_methods/mod.rs
@@ -6,6 +6,7 @@ SPDX-License-Identifier: Apache-2.0 OR MIT
 mod abs;
 mod abs_diff;
 mod count_ones;
+mod count_zeros;
 mod euclid_div_and_rem;
 mod from_bytes;
 mod ilog;


### PR DESCRIPTION
- Adds `count_zeros()` method.
- Modifies `count_ones()` method to return `None` on negative integers, as signed arbitrary precision integers theoretically have an unbounded number of sign bits. This is **BREAKING**.