### PR TITLE
Implement integer square root `isqrt()` method

### DIFF
--- a/arbi/src/builtin_int_methods/isqrt.rs
+++ b/arbi/src/builtin_int_methods/isqrt.rs
@@ -1,0 +1,39 @@
+/*
+Copyright 2025 Owain Davies
+SPDX-License-Identifier: Apache-2.0 OR MIT
+*/
+
+use crate::Arbi;
+
+impl Arbi {
+    /// Returns the integer part (floor) of the square root of `self`.
+    ///
+    /// # Panics
+    /// Panics if `self` is negative.
+    pub fn isqrt(&self) -> Self {
+        if self.is_negative() {
+            panic!("argument of isqrt() cannot be negative")
+        } else if self.is_zero() {
+            Arbi::zero()
+        } else {
+            // TODO
+            unimplemented!()
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::Arbi;
+
+    #[test]
+    #[should_panic = "argument of isqrt() cannot be negative"]
+    fn test_negative_panics() {
+        let _ = Arbi::from(-1).isqrt();
+    }
+
+    #[test]
+    fn test_isqrt_0_is_0() {
+        assert_eq!(Arbi::zero().isqrt(), 0);
+    }
+}

--- a/arbi/src/builtin_int_methods/mod.rs
+++ b/arbi/src/builtin_int_methods/mod.rs
@@ -1,5 +1,5 @@
 /*
-Copyright 2024 Owain Davies
+Copyright 2024-2025 Owain Davies
 SPDX-License-Identifier: Apache-2.0 OR MIT
 */
 
@@ -14,6 +14,7 @@ mod ilog10;
 mod ilog2;
 mod is_positive_is_negative;
 mod is_power_of_two;
+mod isqrt;
 mod reverse_bits;
 mod signum;
 mod swap_bytes;


### PR DESCRIPTION
With Rust 1.84 (2025-01-09) released, `isqrt()` is now stable for primitive integer types. This PR will be used to track the implementation of an integer square root method for an `Arbi` integer.