### PR TITLE
Clean up right/left shift code and add tests for edge cases

### DIFF
--- a/arbi/src/left_shift.rs
+++ b/arbi/src/left_shift.rs
@@ -65,24 +65,6 @@ macro_rules! impl_shl_integral {
     ($($bitcount:ty),*) => {
         $(
 
-/// See [`Shl<u128> for &Arbi`](#impl-Shl<u128>-for-%26Arbi).
-impl Shl<$bitcount> for Arbi {
-    type Output = Arbi;
-    fn shl(mut self, rhs: $bitcount) -> Arbi {
-        self <<= rhs;
-        self
-    }
-}
-
-/// See [`Shl<u128> for &Arbi`](#impl-Shl<u128>-for-%26Arbi).
-impl ShlAssign<$bitcount> for Arbi {
-    #[allow(unused_comparisons)]
-    fn shl_assign(&mut self, rhs: $bitcount) {
-        assert!(rhs >= 0, "Only nonnegative shifts are supported");
-        self.lshift(rhs.try_into().unwrap_or(BitCount::MAX));
-    }
-}
-
 /// Return an `Arbi` integer representing this integer left-shifted `shift` bit
 /// positions with vacated bits zero-filled.
 ///
@@ -91,9 +73,6 @@ impl ShlAssign<$bitcount> for Arbi {
 ///     x \times 2^{\text{shift}}
 /// \\]
 /// where \\( x \\) is the big integer.
-///
-/// This is consistent with Rust's built-in behavior for left-shifting integers
-/// by an unsigned integer value.
 ///
 /// The right-hand-side (RHS) of a left shift operation can be a nonnegative
 /// value of any primitive integer type.
@@ -151,18 +130,43 @@ impl Shl<$bitcount> for &Arbi {
     }
 }
 
-/// See [`Shl<u128> for &Arbi`](#impl-Shl<u128>-for-%26Arbi).
-impl<'a> Shl<&'a $bitcount> for Arbi {
+/// See, for example, [`Shl<u32> for &Arbi`](#impl-Shl<u32>-for-%26Arbi).
+impl<'a> Shl<&'a $bitcount> for &Arbi {
     type Output = Arbi;
-    fn shl(mut self, rhs: &'a $bitcount) -> Arbi {
-        self <<= *rhs;
+    fn shl(self, rhs: &'a $bitcount) -> Arbi {
+        self << *rhs
+    }
+}
+
+/// See, for example, [`Shl<u32> for &Arbi`](#impl-Shl<u32>-for-%26Arbi).
+impl Shl<$bitcount> for Arbi {
+    type Output = Arbi;
+    fn shl(mut self, rhs: $bitcount) -> Arbi {
+        self <<= rhs;
         self
     }
 }
 
-/// See [`Shl<u128> for &Arbi`](#impl-Shl<u128>-for-%26Arbi).
-impl<'a> ShlAssign<&'a $bitcount> for Arbi {
-    fn shl_assign(&mut self, rhs: &'a $bitcount) {
+/// See, for example, [`Shl<u32> for &Arbi`](#impl-Shl<u32>-for-%26Arbi).
+impl Shl<&$bitcount> for Arbi {
+    type Output = Arbi;
+    fn shl(self, rhs: &$bitcount) -> Arbi {
+        self << *rhs
+    }
+}
+
+/// See, for example, [`Shl<u32> for &Arbi`](#impl-Shl<u32>-for-%26Arbi).
+impl ShlAssign<$bitcount> for Arbi {
+    #[allow(unused_comparisons)]
+    fn shl_assign(&mut self, rhs: $bitcount) {
+        assert!(rhs >= 0, "Only nonnegative shifts are supported");
+        self.lshift(rhs.try_into().unwrap_or(BitCount::MAX));
+    }
+}
+
+/// See, for example, [`Shl<u32> for &Arbi`](#impl-Shl<u32>-for-%26Arbi).
+impl ShlAssign<&$bitcount> for Arbi {
+    fn shl_assign(&mut self, rhs: &$bitcount) {
         *self <<= *rhs
     }
 }

--- a/arbi/src/lib.rs
+++ b/arbi/src/lib.rs
@@ -1,5 +1,5 @@
 /*
-Copyright 2024 Owain Davies
+Copyright 2024-2025 Owain Davies
 SPDX-License-Identifier: Apache-2.0 OR MIT
 */
 
@@ -13,8 +13,6 @@ extern crate alloc;
 #[cfg(all(feature = "nightly", test))]
 extern crate test;
 
-#[allow(unused_imports)]
-use alloc::string::String;
 use alloc::vec::Vec;
 
 mod add;
@@ -47,6 +45,7 @@ mod is_odd_is_even;
 mod is_signed;
 mod is_zero;
 mod left_shift;
+mod macros;
 mod multiplication;
 mod negate;
 mod new;

--- a/arbi/src/macros/mod.rs
+++ b/arbi/src/macros/mod.rs
@@ -1,0 +1,12 @@
+/*
+Copyright 2025 Owain Davies
+SPDX-License-Identifier: Apache-2.0 OR MIT
+*/
+
+macro_rules! for_all_integers {
+    ($macro:ident) => {
+        $macro!(i8, i16, i32, i64, i128, isize, u8, u16, u32, u64, u128, usize);
+    };
+}
+
+pub(crate) use for_all_integers;

--- a/arbi/src/right_shift.rs
+++ b/arbi/src/right_shift.rs
@@ -122,11 +122,11 @@ macro_rules! impl_shr_integral {
 /// Panics if `rhs` is negative.
 ///
 /// # Note
-/// Currently, when right-shifting a reference to an `Arbi` (`&Arbi`), the
-/// operation involves cloning the `Arbi` integer, which incurs memory
-/// allocation. To avoid these allocations, prefer using the in-place
-/// right-shift operator `>>=` on a mutable reference (`&mut Arbi`), or the
-/// move-based right-shift operator `>>` on an `Arbi` instance.
+/// When right-shifting a reference to an `Arbi` (`&Arbi`), the operation
+/// involves cloning the `Arbi` integer, which incurs memory allocation. To
+/// avoid these allocations, prefer using the in-place right-shift operator
+/// `>>=` on a mutable reference (`&mut Arbi`), or the move-based right-shift
+/// operator `>>` on an `Arbi` instance.
 ///
 /// # Examples
 /// ```
@@ -153,23 +153,39 @@ macro_rules! impl_shr_integral {
 /// \\( O(n) \\)
 impl Shr<$bitcount> for &Arbi {
     type Output = Arbi;
-    fn shr(self, rhs: $bitcount) -> Self::Output {
+    fn shr(self, rhs: $bitcount) -> Arbi {
         let mut ret = self.clone();
         ret >>= rhs;
         ret
     }
 }
 
-/// See [`impl Shr<u128> for &Arbi`](#impl-Shr<u128>-for-%26Arbi).
+/// See, for example, [`impl Shr<u32> for &Arbi`](#impl-Shr<u32>-for-%26Arbi).
+impl<'a> Shr<&'a $bitcount> for &Arbi {
+    type Output = Arbi;
+    fn shr(self, rhs: &'a $bitcount) -> Arbi {
+        self >> *rhs
+    }
+}
+
+/// See, for example, [`impl Shr<u32> for &Arbi`](#impl-Shr<u32>-for-%26Arbi).
 impl Shr<$bitcount> for Arbi {
     type Output = Arbi;
-    fn shr(mut self, rhs: $bitcount) -> Self::Output {
+    fn shr(mut self, rhs: $bitcount) -> Arbi {
         self >>= rhs;
         self
     }
 }
 
-/// See [`impl Shr<u128> for &Arbi`](#impl-Shr<u128>-for-%26Arbi).
+/// See, for example, [`impl Shr<u32> for &Arbi`](#impl-Shr<u32>-for-%26Arbi).
+impl Shr<&$bitcount> for Arbi {
+    type Output = Arbi;
+    fn shr(self, rhs: &$bitcount) -> Arbi {
+        self >> *rhs
+    }
+}
+
+/// See, for example, [`impl Shr<u32> for &Arbi`](#impl-Shr<u32>-for-%26Arbi).
 impl ShrAssign<$bitcount> for Arbi {
     #[allow(unused_comparisons)]
     fn shr_assign(&mut self, rhs: $bitcount) {
@@ -178,18 +194,10 @@ impl ShrAssign<$bitcount> for Arbi {
     }
 }
 
-/// See [`impl Shr<u128> for &Arbi`](#impl-Shr<u128>-for-%26Arbi).
+/// See, for example, [`impl Shr<u32> for &Arbi`](#impl-Shr<u32>-for-%26Arbi).
 impl ShrAssign<&$bitcount> for Arbi {
     fn shr_assign(&mut self, rhs: &$bitcount) {
         *self >>= *rhs;
-    }
-}
-
-/// See [`impl Shr<u128> for &Arbi`](#impl-Shr<u128>-for-%26Arbi).
-impl<'a> Shr<&'a $bitcount> for &Arbi {
-    type Output = Arbi;
-    fn shr(self, rhs: &'a $bitcount) -> Self::Output {
-        self >> *rhs
     }
 }
 

--- a/arbi/src/right_shift.rs
+++ b/arbi/src/right_shift.rs
@@ -88,7 +88,7 @@ impl Arbi {
             // Add 1 to magnitude
             let mut carry: Digit = 1;
             for digit in self.vec.iter_mut() {
-                *digit += carry;
+                *digit = digit.wrapping_add(carry);
                 carry = Digit::from(*digit == 0);
                 if carry == 0 {
                     break;


### PR DESCRIPTION
- Clean up right/left shift code.
- Add support for right/left shifting by any primitive integer type (negative shifts still panic).
- Add more robust testing, particularly for code paths that randomized testing is highly unlikely to pick up.