### PR TITLE
Bump version to 0.6.0

### DIFF
--- a/arbi/Cargo.toml
+++ b/arbi/Cargo.toml
@@ -18,7 +18,7 @@ license = "Apache-2.0 OR MIT"
 name = "arbi"
 readme = "README.md"
 repository = "https://github.com/OTheDev/arbi"
-version = "0.5.0"
+version = "0.6.0"
 rust-version = "1.65"
 
 [dependencies]


### PR DESCRIPTION
* Extended `rand::distributions::Uniform` to support Arbi ints (#53)
* Added `trailing_zeros()` method (#55)
* Modified `trailing_ones()` method to assume two's complement (#60)
* Added `count_zeros()` method (#59)
* Removed `leading_ones()` method (#62)
* Assume two's complement in `set_bit()`, `test_bit()`, `invert_bit()`, and `clear_bit()` (#54)
* Renamed `doc` module to `docs` and moved long usage guide from README to `docs` module (#64)