### PR TITLE
Deprecate `incr()` and `decr()` methods

### DIFF
--- a/arbi/src/bitwise.rs
+++ b/arbi/src/bitwise.rs
@@ -1,5 +1,5 @@
 /*
-Copyright 2024 Owain Davies
+Copyright 2024-2025 Owain Davies
 SPDX-License-Identifier: Apache-2.0 OR MIT
 */
 
@@ -403,7 +403,7 @@ impl Not for Arbi {
 
     fn not(mut self) -> Self::Output {
         self.negate_mut();
-        self.decr();
+        self -= 1;
         self
     }
 }
@@ -436,7 +436,7 @@ impl Not for &Arbi {
     fn not(self) -> Self::Output {
         let mut ret = self.clone();
         ret.negate_mut();
-        ret.decr();
+        ret -= 1;
         ret
     }
 }

--- a/arbi/src/builtin_int_methods/count_ones.rs
+++ b/arbi/src/builtin_int_methods/count_ones.rs
@@ -101,7 +101,7 @@ mod tests {
             Some(BitCount::from(Digit::MAX.count_ones()))
         );
 
-        a.incr();
+        a += 1;
         assert_eq!(
             a.count_ones(),
             Some(BitCount::from((Digit::MAX as DDigit + 1).count_ones()))

--- a/arbi/src/builtin_int_methods/euclid_div_and_rem.rs
+++ b/arbi/src/builtin_int_methods/euclid_div_and_rem.rs
@@ -1,5 +1,5 @@
 /*
-Copyright 2024 Owain Davies
+Copyright 2024-2025 Owain Davies
 SPDX-License-Identifier: Apache-2.0 OR MIT
 */
 
@@ -149,11 +149,11 @@ impl Arbi {
             if rhs.is_negative() {
                 // rhs < 0
                 rem -= rhs;
-                quot.incr();
+                quot += 1;
             } else {
                 // rhs > 0
                 rem += rhs;
-                quot.decr();
+                quot -= 1;
             }
         }
         (quot, rem)

--- a/arbi/src/builtin_int_methods/ilog.rs
+++ b/arbi/src/builtin_int_methods/ilog.rs
@@ -1,5 +1,5 @@
 /*
-Copyright 2024 Owain Davies
+Copyright 2024-2025 Owain Davies
 SPDX-License-Identifier: Apache-2.0 OR MIT
 */
 
@@ -78,7 +78,7 @@ impl Arbi {
     pub fn ilog_mut(&mut self, base: u32) -> BitCount {
         Self::check_ilog_args(self, base);
         let ret = self.size_base_mut(base) - 1;
-        self.decr();
+        *self -= 1;
         ret
     }
 

--- a/arbi/src/builtin_int_methods/trailing_ones.rs
+++ b/arbi/src/builtin_int_methods/trailing_ones.rs
@@ -178,7 +178,7 @@ mod tests {
             Some(BitCount::from(Digit::MAX.trailing_ones()))
         );
 
-        a.incr();
+        a += 1;
         assert_eq!(
             a.trailing_ones(),
             Some(BitCount::from((Digit::MAX as DDigit + 1).trailing_ones()))

--- a/arbi/src/comparisons_double.rs
+++ b/arbi/src/comparisons_double.rs
@@ -1,5 +1,5 @@
 /*
-Copyright 2024 Owain Davies
+Copyright 2024-2025 Owain Davies
 SPDX-License-Identifier: Apache-2.0 OR MIT
 */
 
@@ -262,14 +262,13 @@ mod tests {
 
         // Boundary around max_double
         assert_eq!(&max_double_mut, MAX_DOUBLE);
-        max_double_mut.incr();
+        max_double_mut += 1;
         assert!(&max_double_mut > MAX_DOUBLE);
-        max_double_mut.decr();
-        max_double_mut.decr();
+        max_double_mut -= 2;
         assert!(&max_double_mut < MAX_DOUBLE);
         assert_eq!(Arbi::from(-MAX_DOUBLE), -MAX_DOUBLE);
-        assert!(Arbi::from(-&max_double).incr() > &mut -MAX_DOUBLE);
-        assert!(Arbi::from(-&max_double).decr() < &mut -MAX_DOUBLE);
+        assert!(Arbi::from(-&max_double) + 1 > -MAX_DOUBLE);
+        assert!(Arbi::from(-&max_double) - 1 < -MAX_DOUBLE);
 
         /* IEEE 754: NaN compared to another floating point number x (where x
          * can be finite, an infinite, or NaN) evaluates to false with >=, <=,

--- a/arbi/src/docs/tour.md
+++ b/arbi/src/docs/tour.md
@@ -243,11 +243,11 @@ integer using [`Arbi::size_bits()`]:
 use arbi::Arbi;
 let mut a = Arbi::zero();
 assert_eq!(a.size_bits(), 0);
-a.incr(); // 1
+a += 1; // 1
 assert_eq!(a.size_bits(), 1);
-a.incr(); // 10
+a += 1; // 10
 assert_eq!(a.size_bits(), 2);
-a.incr(); // 11
+a += 1; // 11
 assert_eq!(a.size_bits(), 2);
 ```
 
@@ -287,26 +287,6 @@ assert_eq!(a.to_f64(), -987654321.0);
 let b = Arbi::from(1_u64 << 32);
 assert_ne!((&b).pow(31_usize).to_f64(), f64::INFINITY);
 assert_eq!((&b).pow(32_usize).to_f64(), f64::INFINITY);
-```
-
-## Increment/Decrement
-
-Increment or decrement an [`Arbi`] integer in-place by one using the
-[`Arbi::incr()`] and [`Arbi::decr()`] methods (`+=` and `-=` can also be used).
-
-```rust
-use arbi::Arbi;
-
-let mut a = Arbi::zero();
-
-a.incr();
-assert_eq!(a, 1);
-
-a.decr();
-assert_eq!(a, 0);
-
-a.decr();
-assert_eq!(a, -1);
 ```
 
 ## Exponentiation

--- a/arbi/src/fits.rs
+++ b/arbi/src/fits.rs
@@ -1,5 +1,5 @@
 /*
-Copyright 2024 Owain Davies
+Copyright 2024-2025 Owain Davies
 SPDX-License-Identifier: Apache-2.0 OR MIT
 */
 
@@ -55,12 +55,9 @@ impl Arbi {
     /// # Examples
     /// ```
     /// use arbi::{Arbi, Fits};
-    ///
     /// let mut x = Arbi::from(255);
     /// assert!(x.fits::<u8>());
-    ///
-    /// x.incr();
-    ///
+    /// x += 1;
     /// assert!(!x.fits::<u8>());
     /// ```
     pub fn fits<T: Fits<T>>(&self) -> bool {

--- a/arbi/src/increment_decrement.rs
+++ b/arbi/src/increment_decrement.rs
@@ -1,5 +1,5 @@
 /*
-Copyright 2024 Owain Davies
+Copyright 2024-2025 Owain Davies
 SPDX-License-Identifier: Apache-2.0 OR MIT
 */
 
@@ -11,11 +11,14 @@ impl Arbi {
     /// # Examples
     /// ```
     /// use arbi::Arbi;
-    ///
     /// let mut x = Arbi::from(987654321);
     /// x.incr();
     /// assert_eq!(x, 987654322);
     /// ```
+    #[deprecated(
+        since = "0.6.1",
+        note = "Please use `x += 1` instead. This will be removed in 0.7.0."
+    )]
     pub fn incr(&mut self) -> &mut Self {
         if self.neg {
             Self::decrement_abs(self);
@@ -33,10 +36,14 @@ impl Arbi {
     /// # Examples
     /// ```
     /// use arbi::Arbi;
-    ///
     /// let mut x = Arbi::from(987654321);
     /// x.decr();
     /// assert_eq!(x, 987654320);
+    /// ```
+    #[deprecated(
+        since = "0.6.1",
+        note = "Please use `x -= 1` instead. This will be removed in 0.7.0."
+    )]
     pub fn decr(&mut self) -> &mut Self {
         if self.neg {
             Self::increment_abs(self);
@@ -113,6 +120,7 @@ impl Arbi {
 }
 
 #[cfg(test)]
+#[allow(deprecated)]
 mod tests {
     use super::*;
     use crate::util::test::{get_seedable_rng, get_uniform_die, Distribution};

--- a/arbi/src/is_odd_is_even.rs
+++ b/arbi/src/is_odd_is_even.rs
@@ -1,5 +1,5 @@
 /*
-Copyright 2024 Owain Davies
+Copyright 2024-2025 Owain Davies
 SPDX-License-Identifier: Apache-2.0 OR MIT
 */
 
@@ -76,7 +76,7 @@ mod tests {
         assert!(arbi.is_odd());
         assert!(!arbi.is_even());
 
-        arbi.decr();
+        arbi -= 1;
         assert!(arbi.is_even());
         assert!(!arbi.is_odd());
     }

--- a/arbi/src/random/uniform_sampler.rs
+++ b/arbi/src/random/uniform_sampler.rs
@@ -1,5 +1,5 @@
 /*
-Copyright 2024 Owain Davies
+Copyright 2024-2025 Owain Davies
 SPDX-License-Identifier: Apache-2.0 OR MIT
 */
 
@@ -45,7 +45,7 @@ impl UniformSampler for UniformArbi {
         let hi_b: &Arbi = hi_incl.borrow();
         assert!(lo_b <= hi_b);
         let mut hi = hi_b.clone();
-        hi.incr();
+        hi += 1;
         UniformArbi {
             lower: lo_b.clone(),
             delta: hi - lo_b,

--- a/arbi/src/size.rs
+++ b/arbi/src/size.rs
@@ -1,5 +1,5 @@
 /*
-Copyright 2024 Owain Davies
+Copyright 2024-2025 Owain Davies
 SPDX-License-Identifier: Apache-2.0 OR MIT
 */
 
@@ -23,7 +23,7 @@ impl Arbi {
     /// let mut a = Arbi::from(Digit::MAX);
     /// assert_eq!(a.size(), 1);
     ///
-    /// a.incr();
+    /// a += 1;
     /// assert_eq!(a.size(), 2);
     /// ```
     ///
@@ -48,7 +48,7 @@ impl Arbi {
     ///
     /// let mut a = Arbi::from(Digit::MAX);
     /// assert_eq!(a.size_bits(), Digit::BITS as BitCount);
-    /// a.incr();
+    /// a += 1;
     /// assert_eq!(a.size_bits(), Digit::BITS as BitCount + 1);
     /// ```
     ///

--- a/arbi/src/to_integral.rs
+++ b/arbi/src/to_integral.rs
@@ -1,5 +1,5 @@
 /*
-Copyright 2024 Owain Davies
+Copyright 2024-2025 Owain Davies
 SPDX-License-Identifier: Apache-2.0 OR MIT
 */
 
@@ -123,7 +123,7 @@ impl Arbi {
     /// use arbi::Arbi;
     /// let mut x = Arbi::from(u8::MAX);
     /// assert!(x.fits_u8());
-    /// x.incr();
+    /// x += 1;
     /// assert!(!x.fits_u8());
     /// ```
     pub fn $fits(&self) -> bool {


### PR DESCRIPTION
* Marks both methods as deprecated.
* Removes all usages of these methods throughout internal code, and doc examples.