### PR TITLE
Bump version to 0.6.1

### DIFF
--- a/arbi/Cargo.toml
+++ b/arbi/Cargo.toml
@@ -18,7 +18,7 @@ license = "Apache-2.0 OR MIT"
 name = "arbi"
 readme = "README.md"
 repository = "https://github.com/OTheDev/arbi"
-version = "0.6.0"
+version = "0.6.1"
 rust-version = "1.65"
 
 [dependencies]


### PR DESCRIPTION
* Deprecated `incr()` and `decr()` methods (#68)