### PR TITLE
Impl. `LowerHex`, `UpperHex`, `Octal`, `Binary` formatting

### DIFF
--- a/arbi/src/docs/tour.md
+++ b/arbi/src/docs/tour.md
@@ -305,15 +305,34 @@ assert_eq!(
 );
 ```
 
-## Display
+## Display/Formatting
 
-The [`core::fmt::Display`] implementation uses the base-10 representation of the
-[`Arbi`] integer and by extension, so does `Arbi::to_string()`.
+`core::fmt`'s [`Display`](Arbi#impl-Display-for-Arbi) trait is implemented for
+`Arbi` integers, which uses its base-10 representation and by extension, so does
+`Arbi::to_string()`.
 
 ```rust
 use arbi::Arbi;
+let a = Arbi::from(-12345);
+assert_eq!(format!("{a}"), "-12345");
+assert_eq!(a.to_string(), "-12345");
+```
 
-let a = Arbi::from(12345);
-assert_eq!(format!("{}", a), "12345");
-assert_eq!(a.to_string(), "12345");
+`core::fmt`'s [`LowerHex`](Arbi#impl-LowerHex-for-Arbi), [`UpperHex`](Arbi#impl-UpperHex-for-Arbi),
+[`Octal`](Arbi#impl-Octal-for-Arbi), and [`Binary`](Arbi#impl-Binary-for-Arbi)
+traits are also implemented. Thus, `x`, `X`, `o`, and `b` formatting are
+supported, with an optional `#` flag for `0x`, `0o`, or `0b` prefixes.
+
+In these cases, the formatted output of an `Arbi`
+integer consists of a `-` prefix for negative values, followed optionally by
+`0x`, `0o`, or `0b` prefixes when the `#` flag is used, and then the magnitude
+in the specified base.
+
+For example:
+
+```rust
+use arbi::Arbi;
+let a = Arbi::from(-0xC0FFEE);
+assert_eq!(format!("{a:x}"), "-c0ffee");
+assert_eq!(format!("{a:#x}"), "-0xc0ffee");
 ```

--- a/arbi/src/fmt/binary.rs
+++ b/arbi/src/fmt/binary.rs
@@ -11,21 +11,18 @@ use core::fmt;
 /// # Examples
 /// ```
 /// use arbi::Arbi;
+///
 /// let mut a = Arbi::from(0xC0FFEE);
-///
-/// assert_eq!(format!("{:b}", a), "110000001111111111101110");
-/// assert_eq!(format!("{:#b}", a), "0b110000001111111111101110");
-///
+/// assert_eq!(format!("{a:b}"), "110000001111111111101110");
+/// assert_eq!(format!("{a:#b}"), "0b110000001111111111101110");
 /// a.negate_mut();
+/// assert_eq!(format!("{a:b}"), "-110000001111111111101110");
+/// assert_eq!(format!("{a:#b}"), "-0b110000001111111111101110");
 ///
-/// assert_eq!(format!("{:b}", a), "-110000001111111111101110");
-/// assert_eq!(format!("{:#b}", a), "-0b110000001111111111101110");
+/// let zero = Arbi::zero();
+/// assert_eq!(format!("{zero:b}"), "0");
+/// assert_eq!(format!("{zero:#b}"), "0b0");
 /// ```
-///
-/// # Note
-/// Unlike primitive signed integers which use two's complement representation,
-/// negative `Arbi` integers are formatted with their magnitude and a `-` prefix
-/// (along with `0b` if `#` is specified).
 impl fmt::Binary for Arbi {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         self.fmt_base(f, BIN, "0b", true)

--- a/arbi/src/fmt/binary.rs
+++ b/arbi/src/fmt/binary.rs
@@ -3,31 +3,31 @@ Copyright 2025 Owain Davies
 SPDX-License-Identifier: Apache-2.0 OR MIT
 */
 
-use crate::{base::OCT, Arbi};
+use crate::{base::BIN, Arbi};
 use core::fmt;
 
-/// Format an `Arbi` integer in octal (base-8).
+/// Format an `Arbi` integer in binary (base-2).
 ///
 /// # Examples
 /// ```
 /// use arbi::Arbi;
 /// let mut a = Arbi::from(0xC0FFEE);
 ///
-/// assert_eq!(format!("{:o}", a), "60177756");
-/// assert_eq!(format!("{:#o}", a), "0o60177756");
+/// assert_eq!(format!("{:b}", a), "110000001111111111101110");
+/// assert_eq!(format!("{:#b}", a), "0b110000001111111111101110");
 ///
 /// a.negate_mut();
 ///
-/// assert_eq!(format!("{:o}", a), "-60177756");
-/// assert_eq!(format!("{:#o}", a), "-0o60177756");
+/// assert_eq!(format!("{:b}", a), "-110000001111111111101110");
+/// assert_eq!(format!("{:#b}", a), "-0b110000001111111111101110");
 /// ```
 ///
 /// # Note
 /// Unlike primitive signed integers which use two's complement representation,
 /// negative `Arbi` integers are formatted with their magnitude and a `-` prefix
-/// (along with `0o` if `#` is specified).
-impl fmt::Octal for Arbi {
+/// (along with `0b` if `#` is specified).
+impl fmt::Binary for Arbi {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        self.fmt_base(f, OCT, "0o", true)
+        self.fmt_base(f, BIN, "0b", true)
     }
 }

--- a/arbi/src/fmt/display.rs
+++ b/arbi/src/fmt/display.rs
@@ -11,8 +11,12 @@ use core::fmt;
 /// # Examples
 /// ```
 /// use arbi::Arbi;
-/// assert_eq!(format!("{}", Arbi::from(12345)), "12345");
-/// assert_eq!(format!("{}", Arbi::from(-12345)), "-12345");
+/// let a = Arbi::from(12345);
+/// assert_eq!(format!("{a}"), "12345");
+/// let b = Arbi::from(-12345);
+/// assert_eq!(format!("{b}"), "-12345");
+/// let zero = Arbi::zero();
+/// assert_eq!(format!("{zero}"), "0");
 /// ```
 impl fmt::Display for Arbi {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {

--- a/arbi/src/fmt/display.rs
+++ b/arbi/src/fmt/display.rs
@@ -1,23 +1,22 @@
 /*
-Copyright 2024 Owain Davies
+Copyright 2024-2025 Owain Davies
 SPDX-License-Identifier: Apache-2.0 OR MIT
 */
 
-use crate::{Arbi, Base};
-use core::fmt::{self, Display};
+use crate::{base::DEC, Arbi};
+use core::fmt;
 
 /// Outputs the base-10 (decimal) representation of an `Arbi` integer.
 ///
 /// # Examples
 /// ```
 /// use arbi::Arbi;
-///
-/// let a = Arbi::from(12345);
-/// assert_eq!(format!("{}", a), "12345");
+/// assert_eq!(format!("{}", Arbi::from(12345)), "12345");
+/// assert_eq!(format!("{}", Arbi::from(-12345)), "-12345");
 /// ```
-impl Display for Arbi {
+impl fmt::Display for Arbi {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", self.to_string_base(Base::try_from(10).unwrap()))
+        write!(f, "{}", self.to_string_base(DEC))
     }
 }
 

--- a/arbi/src/fmt/hex.rs
+++ b/arbi/src/fmt/hex.rs
@@ -11,21 +11,18 @@ use core::fmt;
 /// # Examples
 /// ```
 /// use arbi::Arbi;
+///
 /// let mut a = Arbi::from(0xC0FFEE);
-///
-/// assert_eq!(format!("{:x}", a), "c0ffee");
-/// assert_eq!(format!("{:#x}", a), "0xc0ffee");
-///
+/// assert_eq!(format!("{a:x}"), "c0ffee");
+/// assert_eq!(format!("{a:#x}"), "0xc0ffee");
 /// a.negate_mut();
+/// assert_eq!(format!("{a:x}"), "-c0ffee");
+/// assert_eq!(format!("{a:#x}"), "-0xc0ffee");
 ///
-/// assert_eq!(format!("{:x}", a), "-c0ffee");
-/// assert_eq!(format!("{:#x}", a), "-0xc0ffee");
+/// let zero = Arbi::zero();
+/// assert_eq!(format!("{zero:x}"), "0");
+/// assert_eq!(format!("{zero:#x}"), "0x0");
 /// ```
-///
-/// # Note
-/// Unlike primitive signed integers which use two's complement representation,
-/// negative `Arbi` integers are formatted with their magnitude and a `-` prefix
-/// (along with `0x` if `#` is specified).
 impl fmt::LowerHex for Arbi {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         self.fmt_base(f, HEX, "0x", true)
@@ -37,21 +34,18 @@ impl fmt::LowerHex for Arbi {
 /// # Examples
 /// ```
 /// use arbi::Arbi;
-/// let mut a = Arbi::from(0xC0FFEE);
 ///
+/// let mut a = Arbi::from(0xC0FFEE);
 /// assert_eq!(format!("{:X}", a), "C0FFEE");
 /// assert_eq!(format!("{:#X}", a), "0xC0FFEE");
-///
 /// a.negate_mut();
-///
 /// assert_eq!(format!("{:X}", a), "-C0FFEE");
 /// assert_eq!(format!("{:#X}", a), "-0xC0FFEE");
-/// ```
 ///
-/// # Note
-/// Unlike primitive signed integers which use two's complement representation,
-/// negative `Arbi` integers are formatted with their magnitude and a `-` prefix
-/// (along with `0x` if `#` is specified).
+/// let zero = Arbi::zero();
+/// assert_eq!(format!("{zero:X}"), "0");
+/// assert_eq!(format!("{zero:#X}"), "0x0");
+/// ```
 impl fmt::UpperHex for Arbi {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         self.fmt_base(f, HEX, "0x", false)

--- a/arbi/src/fmt/hex.rs
+++ b/arbi/src/fmt/hex.rs
@@ -11,7 +11,7 @@ use core::fmt;
 /// # Examples
 /// ```
 /// use arbi::Arbi;
-/// let mut a = Arbi::from(12648430);
+/// let mut a = Arbi::from(0xC0FFEE);
 ///
 /// assert_eq!(format!("{:x}", a), "c0ffee");
 /// assert_eq!(format!("{:#x}", a), "0xc0ffee");
@@ -37,7 +37,7 @@ impl fmt::LowerHex for Arbi {
 /// # Examples
 /// ```
 /// use arbi::Arbi;
-/// let mut a = Arbi::from(12648430);
+/// let mut a = Arbi::from(0xC0FFEE);
 ///
 /// assert_eq!(format!("{:X}", a), "C0FFEE");
 /// assert_eq!(format!("{:#X}", a), "0xC0FFEE");

--- a/arbi/src/fmt/hex.rs
+++ b/arbi/src/fmt/hex.rs
@@ -1,0 +1,59 @@
+/*
+Copyright 2025 Owain Davies
+SPDX-License-Identifier: Apache-2.0 OR MIT
+*/
+
+use crate::{base::HEX, Arbi};
+use core::fmt;
+
+/// Format an `Arbi` integer in lowercase hexadecimal (base-16).
+///
+/// # Examples
+/// ```
+/// use arbi::Arbi;
+/// let mut a = Arbi::from(12648430);
+///
+/// assert_eq!(format!("{:x}", a), "c0ffee");
+/// assert_eq!(format!("{:#x}", a), "0xc0ffee");
+///
+/// a.negate_mut();
+///
+/// assert_eq!(format!("{:x}", a), "-c0ffee");
+/// assert_eq!(format!("{:#x}", a), "-0xc0ffee");
+/// ```
+///
+/// # Note
+/// Unlike primitive signed integers which use two's complement representation,
+/// negative `Arbi` integers are formatted with their magnitude and a `-` prefix
+/// (along with `0x` if `#` is specified).
+impl fmt::LowerHex for Arbi {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.fmt_base(f, HEX, "0x", true)
+    }
+}
+
+/// Format an `Arbi` integer in uppercase hexadecimal (base-16).
+///
+/// # Examples
+/// ```
+/// use arbi::Arbi;
+/// let mut a = Arbi::from(12648430);
+///
+/// assert_eq!(format!("{:X}", a), "C0FFEE");
+/// assert_eq!(format!("{:#X}", a), "0xC0FFEE");
+///
+/// a.negate_mut();
+///
+/// assert_eq!(format!("{:X}", a), "-C0FFEE");
+/// assert_eq!(format!("{:#X}", a), "-0xC0FFEE");
+/// ```
+///
+/// # Note
+/// Unlike primitive signed integers which use two's complement representation,
+/// negative `Arbi` integers are formatted with their magnitude and a `-` prefix
+/// (along with `0x` if `#` is specified).
+impl fmt::UpperHex for Arbi {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.fmt_base(f, HEX, "0x", false)
+    }
+}

--- a/arbi/src/fmt/mod.rs
+++ b/arbi/src/fmt/mod.rs
@@ -6,6 +6,7 @@ SPDX-License-Identifier: Apache-2.0 OR MIT
 use crate::{base::Base, Arbi};
 use core::fmt;
 
+mod binary;
 mod display;
 mod hex;
 mod octal;

--- a/arbi/src/fmt/mod.rs
+++ b/arbi/src/fmt/mod.rs
@@ -12,6 +12,8 @@ mod hex;
 mod octal;
 
 impl Arbi {
+    /// Helper for the implementations of `core::fmt`'s `LowerHex`, `UpperHex`,
+    /// `Octal`, and `Binary` traits.
     fn fmt_base(
         &self,
         f: &mut fmt::Formatter<'_>,

--- a/arbi/src/fmt/mod.rs
+++ b/arbi/src/fmt/mod.rs
@@ -1,0 +1,28 @@
+/*
+Copyright 2025 Owain Davies
+SPDX-License-Identifier: Apache-2.0 OR MIT
+*/
+
+use crate::{base::Base, Arbi};
+use core::fmt;
+
+mod display;
+mod hex;
+mod octal;
+
+impl Arbi {
+    fn fmt_base(
+        &self,
+        f: &mut fmt::Formatter<'_>,
+        base: Base,
+        prefix: &str,
+        lowercase: bool,
+    ) -> fmt::Result {
+        let string = self.to_string_base_(base, lowercase);
+        if let Some(s) = string.strip_prefix('-') {
+            f.pad_integral(false, prefix, s)
+        } else {
+            f.pad_integral(true, prefix, &string)
+        }
+    }
+}

--- a/arbi/src/fmt/octal.rs
+++ b/arbi/src/fmt/octal.rs
@@ -1,0 +1,33 @@
+/*
+Copyright 2025 Owain Davies
+SPDX-License-Identifier: Apache-2.0 OR MIT
+*/
+
+use crate::{base::OCT, Arbi};
+use core::fmt;
+
+/// Format an `Arbi` integer in octal (base-8).
+///
+/// # Examples
+/// ```
+/// use arbi::Arbi;
+/// let mut a = Arbi::from(12648430);
+///
+/// assert_eq!(format!("{:o}", a), "60177756");
+/// assert_eq!(format!("{:#o}", a), "0o60177756");
+///
+/// a.negate_mut();
+///
+/// assert_eq!(format!("{:o}", a), "-60177756");
+/// assert_eq!(format!("{:#o}", a), "-0o60177756");
+/// ```
+///
+/// # Note
+/// Unlike primitive signed integers which use two's complement representation,
+/// negative `Arbi` integers are formatted with their magnitude and a `-` prefix
+/// (along with `0o` if `#` is specified).
+impl fmt::Octal for Arbi {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.fmt_base(f, OCT, "0o", true)
+    }
+}

--- a/arbi/src/fmt/octal.rs
+++ b/arbi/src/fmt/octal.rs
@@ -11,21 +11,18 @@ use core::fmt;
 /// # Examples
 /// ```
 /// use arbi::Arbi;
+///
 /// let mut a = Arbi::from(0xC0FFEE);
-///
-/// assert_eq!(format!("{:o}", a), "60177756");
-/// assert_eq!(format!("{:#o}", a), "0o60177756");
-///
+/// assert_eq!(format!("{a:o}"), "60177756");
+/// assert_eq!(format!("{a:#o}"), "0o60177756");
 /// a.negate_mut();
+/// assert_eq!(format!("{a:o}"), "-60177756");
+/// assert_eq!(format!("{a:#o}"), "-0o60177756");
 ///
-/// assert_eq!(format!("{:o}", a), "-60177756");
-/// assert_eq!(format!("{:#o}", a), "-0o60177756");
+/// let zero = Arbi::zero();
+/// assert_eq!(format!("{zero:o}"), "0");
+/// assert_eq!(format!("{zero:#o}"), "0o0");
 /// ```
-///
-/// # Note
-/// Unlike primitive signed integers which use two's complement representation,
-/// negative `Arbi` integers are formatted with their magnitude and a `-` prefix
-/// (along with `0o` if `#` is specified).
 impl fmt::Octal for Arbi {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         self.fmt_base(f, OCT, "0o", true)

--- a/arbi/src/lib.rs
+++ b/arbi/src/lib.rs
@@ -28,7 +28,6 @@ mod capacity;
 mod comparisons;
 mod comparisons_double;
 mod comparisons_integral;
-mod display;
 mod division;
 #[allow(unknown_lints)]
 #[allow(clippy::doc_lazy_continuation)]
@@ -36,6 +35,7 @@ pub mod docs;
 mod exponentiation;
 mod fits;
 mod floor;
+mod fmt;
 mod from_double;
 mod from_integral;
 mod from_string;

--- a/arbi/src/to_string.rs
+++ b/arbi/src/to_string.rs
@@ -85,24 +85,22 @@ impl Arbi {
         }
     }
 
-    /// Return a [`String`] containing the base-`base` representation of the
-    /// integer, where `base` must be an integer in \\( [2, 36] \\).
-    ///
-    /// # Examples
-    /// ```
-    /// use arbi::{Arbi, Base};
-    ///
-    /// let b10 = Base::try_from(10).unwrap();
-    ///
-    /// let a = Arbi::from(123456789);
-    /// let s = a.to_string_base(b10);
-    /// assert_eq!(s, "123456789");
-    /// ```
-    pub fn to_string_base(&self, base: Base) -> String {
+    pub(crate) fn to_string_base_(
+        &self,
+        base: Base,
+        lowercase: bool,
+    ) -> String {
         let base: usize = base.value() as usize;
         assert!((2..=36).contains(&base));
 
-        const BASE_DIGITS: &str = "0123456789abcdefghijklmnopqrstuvwxyz";
+        const BASE_DIGITS_LOWER: &str = "0123456789abcdefghijklmnopqrstuvwxyz";
+        const BASE_DIGITS_UPPER: &str = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ";
+
+        let base_digits = if lowercase {
+            BASE_DIGITS_LOWER
+        } else {
+            BASE_DIGITS_UPPER
+        };
 
         if self.size() == 0 {
             return "0".into();
@@ -151,7 +149,7 @@ impl Arbi {
                 remainder /= base as Digit;
 
                 result.push(
-                    BASE_DIGITS.chars().nth(current_digit as usize).unwrap(),
+                    base_digits.chars().nth(current_digit as usize).unwrap(),
                 );
             }
         }
@@ -161,6 +159,23 @@ impl Arbi {
         }
 
         result.chars().rev().collect::<String>()
+    }
+
+    /// Return a [`String`] containing the base-`base` representation of the
+    /// integer, where `base` must be an integer in \\( [2, 36] \\).
+    ///
+    /// # Examples
+    /// ```
+    /// use arbi::{
+    ///     base::{DEC, HEX},
+    ///     Arbi,
+    /// };
+    /// assert_eq!(Arbi::from(123456789).to_string_base(DEC), "123456789");
+    /// assert_eq!(Arbi::from(123456789).to_string_base(HEX), "75bcd15");
+    /// assert_eq!(Arbi::from(-123456789).to_string_base(HEX), "-75bcd15");
+    /// ```
+    pub fn to_string_base(&self, base: Base) -> String {
+        self.to_string_base_(base, true)
     }
 
     /// Equivalent to [`Arbi::to_string_base()`], but panics if the base is


### PR DESCRIPTION
In this PR, `core::fmt`'s `LowerHex`, `UpperHex`, `Octal`, and `Binary` traits are implemented, thereby supporting `x`, `X`, `o`, and `b` formatting (with an optional `#` flag for `0x`, `0o`, or `0b` prefixes), respectively.

## Note

Unlike primitive signed integers which format negative integers in hexadecimal, octal, or binary using two's complement representation, negative `Arbi` integers are formatted with a `-` prefix along with `0x`, `0o`, or `0b` if the optional `#` flag is specified, followed by their magnitude.

This is clear from the newly added section in `docs::tour`, as well as from the examples in the documentation for each implementation.

## TODO

- [x] Add section in `docs::tour` describing the newly added functionality.
- [x] The `Note` section in the documentation for each trait implementation might be a little repetitive. Review.
- [x] Should we implement `LowerExp` and `UpperExp`?