### PR TITLE
Optimize AND, IOR, XOR and support bitops with primitives

### DIFF
--- a/arbi/src/left_shift.rs
+++ b/arbi/src/left_shift.rs
@@ -3,7 +3,7 @@ Copyright 2024-2025 Owain Davies
 SPDX-License-Identifier: Apache-2.0 OR MIT
 */
 
-use crate::macros::for_all_integers;
+use crate::macros::for_all_ints;
 use crate::{Arbi, BitCount, Digit};
 use core::ops::{Shl, ShlAssign};
 
@@ -176,7 +176,7 @@ impl ShlAssign<&$bitcount> for Arbi {
 }
 /* impl_shl_integral! */
 
-for_all_integers!(impl_shl_integral);
+for_all_ints!(impl_shl_integral);
 
 #[cfg(test)]
 mod tests {

--- a/arbi/src/lib.rs
+++ b/arbi/src/lib.rs
@@ -22,7 +22,6 @@ mod assign_integral;
 mod assign_string;
 pub mod base;
 mod bits;
-mod bitwise;
 mod builtin_int_methods;
 mod capacity;
 mod comparisons;
@@ -48,6 +47,7 @@ mod macros;
 mod multiplication;
 mod negate;
 mod new;
+mod ops;
 mod print_internal;
 mod random;
 mod right_shift;
@@ -239,5 +239,15 @@ impl Arbi {
         self.vec.extend_from_slice(digits);
         self.neg = is_negative;
         self.trim();
+    }
+
+    /// Ensures `self` has the larger capacity by swapping with `other` if
+    /// desired.
+    ///
+    /// This can help avoid additional memory allocation.
+    pub(crate) fn swap_if_smaller_capacity(&mut self, other: &mut Self) {
+        if other.vec.capacity() > self.vec.capacity() {
+            core::mem::swap(self, other);
+        }
     }
 }

--- a/arbi/src/macros/mod.rs
+++ b/arbi/src/macros/mod.rs
@@ -3,10 +3,37 @@ Copyright 2025 Owain Davies
 SPDX-License-Identifier: Apache-2.0 OR MIT
 */
 
-macro_rules! for_all_integers {
+// ($($int:ty),*) => {}
+macro_rules! for_all_ints {
     ($macro:ident) => {
         $macro!(i8, i16, i32, i64, i128, isize, u8, u16, u32, u64, u128, usize);
     };
 }
 
-pub(crate) use for_all_integers;
+// ($(($int:ty, $uint:ty, $max_size:expr)),*) => {}
+macro_rules! for_all_ints_with_metadata {
+    ($macro:ident) => {
+        $macro!(
+            // ($int:ty, $uint:ty, $max_size:expr)
+            // int      : any primitive integer type
+            // uint     : unsigned primitive integer type of same width as int
+            // max_size : maximum number of base Arbi::BASE digits needed to
+            //            represent the maximum value of this type
+            (i8, u8, { crate::util::max_digits::<i8>() }),
+            (u8, u8, { crate::util::max_digits::<u8>() }),
+            (i16, u16, { crate::util::max_digits::<i16>() }),
+            (u16, u16, { crate::util::max_digits::<u16>() }),
+            (i32, u32, { crate::util::max_digits::<i32>() }),
+            (u32, u32, { crate::util::max_digits::<u32>() }),
+            (i64, u64, { crate::util::max_digits::<i64>() }),
+            (u64, u64, { crate::util::max_digits::<u64>() }),
+            (i128, u128, { crate::util::max_digits::<i128>() }),
+            (u128, u128, { crate::util::max_digits::<u128>() }),
+            (isize, usize, { crate::util::max_digits::<isize>() }),
+            (usize, usize, { crate::util::max_digits::<usize>() })
+        );
+    };
+}
+
+pub(crate) use for_all_ints;
+pub(crate) use for_all_ints_with_metadata;

--- a/arbi/src/ops/bit/arbi_x_arbi.rs
+++ b/arbi/src/ops/bit/arbi_x_arbi.rs
@@ -195,8 +195,8 @@ impl<'a> BitXorAssign<&'a Arbi> for Arbi {
 impl Not for Arbi {
     type Output = Arbi;
     fn not(mut self) -> Self::Output {
+        self += 1;
         self.negate_mut();
-        self -= 1;
         self
     }
 }
@@ -204,7 +204,7 @@ impl Not for Arbi {
 /// Unary complement operator. Return a new integer representing the ones'
 /// complement of this integer.
 ///
-/// Currently, this involves cloning the referenced `Arbi` integer.
+/// This involves cloning the referenced `Arbi` integer.
 ///
 /// # Example
 /// ```
@@ -226,10 +226,7 @@ impl Not for Arbi {
 impl Not for &Arbi {
     type Output = Arbi;
     fn not(self) -> Self::Output {
-        let mut ret = self.clone();
-        ret.negate_mut();
-        ret -= 1;
-        ret
+        !(self.clone())
     }
 }
 

--- a/arbi/src/ops/bit/arbi_x_arbi.rs
+++ b/arbi/src/ops/bit/arbi_x_arbi.rs
@@ -3,177 +3,18 @@ Copyright 2024-2025 Owain Davies
 SPDX-License-Identifier: Apache-2.0 OR MIT
 */
 
-//! Bitwise operators
-//!
-//! These operators (!, &, |, ^, &=, |=, ^=) perform bitwise operations on
-//! integers using two's complement representation (with sign extension).
-
-// TODO:
-// 1. Add examples for BitOr, BitAnd, and BitXor.
-// 2. Document under what situations cloning is needed.
-// 3. Ideally, there should only be one implementation.
-
-use crate::to_twos_complement::{ByteOrder, TwosComplement};
-use crate::{Arbi, Digit};
+use crate::Arbi;
 use core::ops::{
     BitAnd, BitAndAssign, BitOr, BitOrAssign, BitXor, BitXorAssign, Not,
 };
-
-#[allow(dead_code)]
-#[derive(Debug, Copy, Clone)]
-pub enum BitwiseOperation {
-    And,
-    Or,
-    Xor,
-}
-
-impl Arbi {
-    fn bitwise_operation_inplace_impl(
-        x: &mut Self,
-        y: &Self,
-        op: BitwiseOperation,
-    ) {
-        let x_negative = x.is_negative();
-        let y_negative = y.is_negative();
-
-        let mut max_size = x.size().max(y.size());
-
-        if x_negative {
-            x.vec.to_twos_complement(ByteOrder::Le);
-        }
-
-        let y_temp_complement = if y_negative {
-            let mut y_clone = y.vec.clone();
-            y_clone.to_twos_complement(ByteOrder::Le);
-            Some(y_clone)
-        } else {
-            None
-        };
-
-        let y_digits = if y_negative {
-            y_temp_complement.as_ref().unwrap()
-        } else {
-            &y.vec
-        };
-
-        let result_negative = match op {
-            BitwiseOperation::And => x_negative && y_negative,
-            BitwiseOperation::Or => x_negative || y_negative,
-            BitwiseOperation::Xor => {
-                max_size += 1;
-                x_negative != y_negative
-            }
-        };
-
-        x.vec
-            .resize(max_size, if x_negative { Digit::MAX } else { 0 });
-
-        for i in 0..max_size {
-            let lhs_digit = if i < x.size() {
-                x.vec[i]
-            } else if x_negative {
-                Digit::MAX
-            } else {
-                0
-            };
-
-            let rhs_digit = if i < y_digits.len() {
-                y_digits[i]
-            } else if y_negative {
-                Digit::MAX
-            } else {
-                0
-            };
-
-            x.vec[i] = match op {
-                BitwiseOperation::And => lhs_digit & rhs_digit,
-                BitwiseOperation::Or => lhs_digit | rhs_digit,
-                BitwiseOperation::Xor => lhs_digit ^ rhs_digit,
-            };
-        }
-
-        if result_negative {
-            x.vec.to_twos_complement(ByteOrder::Le);
-        }
-
-        x.neg = result_negative;
-        x.trim();
-    }
-
-    fn bitwise_operation_inplace_impl_mut(
-        x: &mut Self,
-        y: &mut Self,
-        op: BitwiseOperation,
-    ) {
-        let x_negative = x.is_negative();
-        let y_negative = y.is_negative();
-
-        let mut max_size = x.size().max(y.size());
-
-        if x_negative {
-            x.vec.to_twos_complement(ByteOrder::Le);
-        }
-
-        if y_negative {
-            y.vec.to_twos_complement(ByteOrder::Le);
-        }
-
-        let result_negative = match op {
-            BitwiseOperation::And => x_negative && y_negative,
-            BitwiseOperation::Or => x_negative || y_negative,
-            BitwiseOperation::Xor => {
-                max_size += 1;
-                x_negative != y_negative
-            }
-        };
-
-        x.vec
-            .resize(max_size, if x_negative { Digit::MAX } else { 0 });
-
-        for i in 0..max_size {
-            let lhs_digit = if i < x.size() {
-                x.vec[i]
-            } else if x_negative {
-                Digit::MAX
-            } else {
-                0
-            };
-
-            let rhs_digit = if i < y.size() {
-                y.vec[i]
-            } else if y_negative {
-                Digit::MAX
-            } else {
-                0
-            };
-
-            x.vec[i] = match op {
-                BitwiseOperation::And => lhs_digit & rhs_digit,
-                BitwiseOperation::Or => lhs_digit | rhs_digit,
-                BitwiseOperation::Xor => lhs_digit ^ rhs_digit,
-            };
-        }
-
-        if result_negative {
-            x.vec.to_twos_complement(ByteOrder::Le);
-        }
-
-        x.neg = result_negative;
-        x.trim();
-    }
-}
 
 /// See [BitAnd](#impl-BitAnd<%26Arbi>-for-%26Arbi) for the mathematical
 /// semantics.
 impl BitAnd<Arbi> for Arbi {
     type Output = Arbi;
-
     fn bitand(mut self, mut rhs: Self) -> Self::Output {
-        Self::bitwise_operation_inplace_impl_mut(
-            &mut self,
-            &mut rhs,
-            BitwiseOperation::And,
-        );
+        self.swap_if_smaller_capacity(&mut rhs);
+        self.inplace_bitwise_and(&rhs);
         self
     }
 }
@@ -182,13 +23,8 @@ impl BitAnd<Arbi> for Arbi {
 /// semantics.
 impl<'a> BitAnd<&'a Arbi> for Arbi {
     type Output = Arbi;
-
     fn bitand(mut self, rhs: &'a Self) -> Self::Output {
-        Self::bitwise_operation_inplace_impl(
-            &mut self,
-            rhs,
-            BitwiseOperation::And,
-        );
+        self.inplace_bitwise_and(rhs);
         self
     }
 }
@@ -202,15 +38,10 @@ impl<'a> BitAnd<&'a Arbi> for Arbi {
 /// \\]
 impl<'a> BitAnd<&'a Arbi> for &Arbi {
     type Output = Arbi;
-
     fn bitand(self, rhs: &'a Arbi) -> Self::Output {
-        let mut result = self.clone();
-        Arbi::bitwise_operation_inplace_impl(
-            &mut result,
-            rhs,
-            BitwiseOperation::And,
-        );
-        result
+        let mut ret = Arbi::zero();
+        ret.assign_bitwise_and(self, rhs);
+        ret
     }
 }
 
@@ -218,11 +49,8 @@ impl<'a> BitAnd<&'a Arbi> for &Arbi {
 /// semantics.
 impl BitAndAssign<Arbi> for Arbi {
     fn bitand_assign(&mut self, mut rhs: Self) {
-        Arbi::bitwise_operation_inplace_impl_mut(
-            self,
-            &mut rhs,
-            BitwiseOperation::And,
-        );
+        self.swap_if_smaller_capacity(&mut rhs);
+        self.inplace_bitwise_and(&rhs);
     }
 }
 
@@ -230,7 +58,7 @@ impl BitAndAssign<Arbi> for Arbi {
 /// semantics.
 impl<'a> BitAndAssign<&'a Arbi> for Arbi {
     fn bitand_assign(&mut self, rhs: &'a Self) {
-        Arbi::bitwise_operation_inplace_impl(self, rhs, BitwiseOperation::And);
+        self.inplace_bitwise_and(rhs);
     }
 }
 
@@ -238,13 +66,9 @@ impl<'a> BitAndAssign<&'a Arbi> for Arbi {
 /// semantics.
 impl BitOr<Arbi> for Arbi {
     type Output = Arbi;
-
     fn bitor(mut self, mut rhs: Self) -> Self::Output {
-        Self::bitwise_operation_inplace_impl_mut(
-            &mut self,
-            &mut rhs,
-            BitwiseOperation::Or,
-        );
+        self.swap_if_smaller_capacity(&mut rhs);
+        self.inplace_bitwise_ior(&rhs);
         self
     }
 }
@@ -253,13 +77,8 @@ impl BitOr<Arbi> for Arbi {
 /// semantics.
 impl<'a> BitOr<&'a Arbi> for Arbi {
     type Output = Arbi;
-
     fn bitor(mut self, rhs: &'a Self) -> Self::Output {
-        Self::bitwise_operation_inplace_impl(
-            &mut self,
-            rhs,
-            BitwiseOperation::Or,
-        );
+        self.inplace_bitwise_ior(rhs);
         self
     }
 }
@@ -273,15 +92,10 @@ impl<'a> BitOr<&'a Arbi> for Arbi {
 /// \\]
 impl<'a> BitOr<&'a Arbi> for &Arbi {
     type Output = Arbi;
-
     fn bitor(self, rhs: &'a Arbi) -> Self::Output {
-        let mut result = self.clone();
-        Arbi::bitwise_operation_inplace_impl(
-            &mut result,
-            rhs,
-            BitwiseOperation::Or,
-        );
-        result
+        let mut ret = Arbi::zero();
+        ret.assign_bitwise_ior(self, rhs);
+        ret
     }
 }
 
@@ -289,11 +103,8 @@ impl<'a> BitOr<&'a Arbi> for &Arbi {
 /// semantics.
 impl BitOrAssign<Arbi> for Arbi {
     fn bitor_assign(&mut self, mut rhs: Self) {
-        Arbi::bitwise_operation_inplace_impl_mut(
-            self,
-            &mut rhs,
-            BitwiseOperation::Or,
-        );
+        self.swap_if_smaller_capacity(&mut rhs);
+        self.inplace_bitwise_ior(&rhs);
     }
 }
 
@@ -301,7 +112,7 @@ impl BitOrAssign<Arbi> for Arbi {
 /// semantics.
 impl<'a> BitOrAssign<&'a Arbi> for Arbi {
     fn bitor_assign(&mut self, rhs: &'a Self) {
-        Arbi::bitwise_operation_inplace_impl(self, rhs, BitwiseOperation::Or);
+        self.inplace_bitwise_ior(rhs);
     }
 }
 
@@ -309,13 +120,9 @@ impl<'a> BitOrAssign<&'a Arbi> for Arbi {
 /// semantics.
 impl BitXor<Arbi> for Arbi {
     type Output = Arbi;
-
     fn bitxor(mut self, mut rhs: Self) -> Self::Output {
-        Self::bitwise_operation_inplace_impl_mut(
-            &mut self,
-            &mut rhs,
-            BitwiseOperation::Xor,
-        );
+        self.swap_if_smaller_capacity(&mut rhs);
+        self.inplace_bitwise_xor(&rhs);
         self
     }
 }
@@ -324,13 +131,8 @@ impl BitXor<Arbi> for Arbi {
 /// semantics.
 impl<'a> BitXor<&'a Arbi> for Arbi {
     type Output = Arbi;
-
     fn bitxor(mut self, rhs: &'a Self) -> Self::Output {
-        Self::bitwise_operation_inplace_impl(
-            &mut self,
-            rhs,
-            BitwiseOperation::Xor,
-        );
+        self.inplace_bitwise_xor(rhs);
         self
     }
 }
@@ -345,15 +147,10 @@ impl<'a> BitXor<&'a Arbi> for Arbi {
 /// \\]
 impl<'a> BitXor<&'a Arbi> for &Arbi {
     type Output = Arbi;
-
     fn bitxor(self, rhs: &'a Arbi) -> Self::Output {
-        let mut result = self.clone();
-        Arbi::bitwise_operation_inplace_impl(
-            &mut result,
-            rhs,
-            BitwiseOperation::Xor,
-        );
-        result
+        let mut ret = Arbi::zero();
+        ret.assign_bitwise_xor(self, rhs);
+        ret
     }
 }
 
@@ -361,11 +158,8 @@ impl<'a> BitXor<&'a Arbi> for &Arbi {
 /// semantics.
 impl BitXorAssign<Arbi> for Arbi {
     fn bitxor_assign(&mut self, mut rhs: Self) {
-        Arbi::bitwise_operation_inplace_impl_mut(
-            self,
-            &mut rhs,
-            BitwiseOperation::Xor,
-        );
+        self.swap_if_smaller_capacity(&mut rhs);
+        self.inplace_bitwise_xor(&rhs);
     }
 }
 
@@ -373,7 +167,7 @@ impl BitXorAssign<Arbi> for Arbi {
 /// semantics.
 impl<'a> BitXorAssign<&'a Arbi> for Arbi {
     fn bitxor_assign(&mut self, rhs: &'a Self) {
-        Arbi::bitwise_operation_inplace_impl(self, rhs, BitwiseOperation::Xor);
+        self.inplace_bitwise_xor(rhs);
     }
 }
 
@@ -400,7 +194,6 @@ impl<'a> BitXorAssign<&'a Arbi> for Arbi {
 /// \\( O(n) \\)
 impl Not for Arbi {
     type Output = Arbi;
-
     fn not(mut self) -> Self::Output {
         self.negate_mut();
         self -= 1;
@@ -432,7 +225,6 @@ impl Not for Arbi {
 /// \\( O(n) \\)
 impl Not for &Arbi {
     type Output = Arbi;
-
     fn not(self) -> Self::Output {
         let mut ret = self.clone();
         ret.negate_mut();

--- a/arbi/src/ops/bit/arbi_x_int.rs
+++ b/arbi/src/ops/bit/arbi_x_int.rs
@@ -1,0 +1,283 @@
+/*
+Copyright 2025 Owain Davies
+SPDX-License-Identifier: Apache-2.0 OR MIT
+*/
+
+/*
+Let ⊕ denote any one of &, |, ^. Let a denote an (owned) arbitary Arbi and i an
+arbitrary primitive integer. Let a' denote the result (an Arbi). Here, "inplace"
+means memory allocation need not occur if there's already enough capacity in a.
+
+Implements:
+    1. a ⊕= i           (inplace)
+    2. a ⊕ i    => a'   (inplace)
+    3. i ⊕ a    => a'   (inplace)
+    4. &a ⊕ i   => a'   (clone)
+    5. i ⊕ &a   => a'   (clone)
+
+Moreover, there's already code implemented that can be used to assign the result
+of (4) and (5) to an existing buffer, potentially avoiding memory allocation,
+but first, an API needs to be decided for expressing such operations.
+
+The same five combinations are also implemented with i replaced by &i, for
+convenience.
+*/
+
+use crate::macros::for_all_ints;
+use crate::ops::bit::impls::BitwiseOp;
+use crate::util::IntoArbiLikeArray;
+use crate::Arbi;
+use core::ops::{
+    BitAnd, BitAndAssign, BitOr, BitOrAssign, BitXor, BitXorAssign,
+};
+
+/* !impl_bit_with_int */
+macro_rules! impl_bit_with_int {
+    ($($int:ty),*) => {
+        $(
+
+/* (1) a ⊕= i */
+impl BitAndAssign<$int> for Arbi {
+    fn bitand_assign(&mut self, rhs: $int) {
+        let rhs = rhs.into_arbi_like_array();
+        self.inplace_bitwise_op_with_arbi_like_view((&rhs).into(), BitwiseOp::And);
+    }
+}
+
+impl BitOrAssign<$int> for Arbi {
+    fn bitor_assign(&mut self, rhs: $int) {
+        let rhs = rhs.into_arbi_like_array();
+        self.inplace_bitwise_op_with_arbi_like_view((&rhs).into(), BitwiseOp::Ior);
+    }
+}
+
+impl BitXorAssign<$int> for Arbi {
+    fn bitxor_assign(&mut self, rhs: $int) {
+        let rhs = rhs.into_arbi_like_array();
+        self.inplace_bitwise_op_with_arbi_like_view((&rhs).into(), BitwiseOp::Xor);
+    }
+}
+
+/* (2) a ⊕ i => a' */
+impl BitAnd<$int> for Arbi {
+    type Output = Arbi;
+    fn bitand(mut self, rhs: $int) -> Arbi {
+        self &= rhs;
+        self
+    }
+}
+
+impl BitOr<$int> for Arbi {
+    type Output = Arbi;
+    fn bitor(mut self, rhs: $int) -> Arbi {
+        self |= rhs;
+        self
+    }
+}
+
+impl BitXor<$int> for Arbi {
+    type Output = Arbi;
+    fn bitxor(mut self, rhs: $int) -> Arbi {
+        self ^= rhs;
+        self
+    }
+}
+
+/* (3) i ⊕ a => a' */
+impl BitAnd<Arbi> for $int {
+    type Output = Arbi;
+    fn bitand(self, mut rhs: Arbi) -> Arbi {
+        rhs &= self;
+        rhs
+    }
+}
+
+impl BitOr<Arbi> for $int {
+    type Output = Arbi;
+    fn bitor(self, mut rhs: Arbi) -> Arbi {
+        rhs |= self;
+        rhs
+    }
+}
+
+impl BitXor<Arbi> for $int {
+    type Output = Arbi;
+    fn bitxor(self, mut rhs: Arbi) -> Arbi {
+        rhs ^= self;
+        rhs
+    }
+}
+
+/* (4) &a ⊕ i => a' */
+impl BitAnd<$int> for &Arbi {
+    type Output = Arbi;
+    fn bitand(self, rhs: $int) -> Arbi {
+        self.clone() & rhs
+    }
+}
+
+impl BitOr<$int> for &Arbi {
+    type Output = Arbi;
+    fn bitor(self, rhs: $int) -> Arbi {
+        self.clone() | rhs
+    }
+}
+
+impl BitXor<$int> for &Arbi {
+    type Output = Arbi;
+    fn bitxor(self, rhs: $int) -> Arbi {
+        self.clone() ^ rhs
+    }
+}
+
+/* (5) i ⊕ &a => a' */
+impl BitAnd<&Arbi> for $int {
+    type Output = Arbi;
+    fn bitand(self, rhs: &Arbi) -> Arbi {
+        rhs & self
+    }
+}
+
+impl BitOr<&Arbi> for $int {
+    type Output = Arbi;
+    fn bitor(self, rhs: &Arbi) -> Arbi {
+        rhs | self
+    }
+}
+
+impl BitXor<&Arbi> for $int {
+    type Output = Arbi;
+    fn bitxor(self, rhs: &Arbi) -> Arbi {
+        rhs ^ self
+    }
+}
+
+        )*
+    };
+}
+/* impl_bit_with_int! */
+
+for_all_ints!(impl_bit_with_int);
+
+// Implements the same combinations as impl_bit_with_int but with &i instead of
+// i, using the above implementations.
+//
+// TODO: Can we use a macro to avoid doing this for every binop?
+/* !impl_bit_with_int_ref */
+macro_rules! impl_bit_with_int_ref {
+    ($($int:ty),*) => {
+        $(
+
+/* (1) a ⊕= &i */
+impl BitAndAssign<&$int> for Arbi {
+    fn bitand_assign(&mut self, rhs: &$int) {
+        (*self) &= (*rhs);
+    }
+}
+
+impl BitOrAssign<&$int> for Arbi {
+    fn bitor_assign(&mut self, rhs: &$int) {
+        (*self) |= (*rhs);
+    }
+}
+
+impl BitXorAssign<&$int> for Arbi {
+    fn bitxor_assign(&mut self, rhs: &$int) {
+        (*self) ^= (*rhs);
+    }
+}
+
+/* (2) a ⊕ &i => a' */
+impl BitAnd<&$int> for Arbi {
+    type Output = Arbi;
+    fn bitand(self, rhs: &$int) -> Arbi {
+        self & (*rhs)
+    }
+}
+
+impl BitOr<&$int> for Arbi {
+    type Output = Arbi;
+    fn bitor(self, rhs: &$int) -> Arbi {
+        self | (*rhs)
+    }
+}
+
+impl BitXor<&$int> for Arbi {
+    type Output = Arbi;
+    fn bitxor(self, rhs: &$int) -> Arbi {
+        self ^ (*rhs)
+    }
+}
+
+/* (3) &i ⊕ a => a' */
+impl BitAnd<Arbi> for &$int {
+    type Output = Arbi;
+    fn bitand(self, rhs: Arbi) -> Arbi {
+        (*self) & rhs
+    }
+}
+
+impl BitOr<Arbi> for &$int {
+    type Output = Arbi;
+    fn bitor(self, rhs: Arbi) -> Arbi {
+        (*self) | rhs
+    }
+}
+
+impl BitXor<Arbi> for &$int {
+    type Output = Arbi;
+    fn bitxor(self, rhs: Arbi) -> Arbi {
+        (*self) ^ rhs
+    }
+}
+
+/* (4) &a ⊕ &i => a' */
+impl BitAnd<&$int> for &Arbi {
+    type Output = Arbi;
+    fn bitand(self, rhs: &$int) -> Arbi {
+        self & (*rhs)
+    }
+}
+
+impl BitOr<&$int> for &Arbi {
+    type Output = Arbi;
+    fn bitor(self, rhs: &$int) -> Arbi {
+        self | (*rhs)
+    }
+}
+
+impl BitXor<&$int> for &Arbi {
+    type Output = Arbi;
+    fn bitxor(self, rhs: &$int) -> Arbi {
+        self ^ (*rhs)
+    }
+}
+
+/* (5) &i ⊕ &a => a' */
+impl BitAnd<&Arbi> for &$int {
+    type Output = Arbi;
+    fn bitand(self, rhs: &Arbi) -> Arbi {
+        (*self) & rhs
+    }
+}
+
+impl BitOr<&Arbi> for &$int {
+    type Output = Arbi;
+    fn bitor(self, rhs: &Arbi) -> Arbi {
+        (*self) | rhs
+    }
+}
+
+impl BitXor<&Arbi> for &$int {
+    type Output = Arbi;
+    fn bitxor(self, rhs: &Arbi) -> Arbi {
+        (*self) ^ rhs
+    }
+}
+
+        )*
+    };
+}
+/* impl_bit_with_int_ref! */
+
+for_all_ints!(impl_bit_with_int_ref);

--- a/arbi/src/ops/bit/impls.rs
+++ b/arbi/src/ops/bit/impls.rs
@@ -1,0 +1,567 @@
+/*
+Copyright 2025 Owain Davies
+SPDX-License-Identifier: Apache-2.0 OR MIT
+*/
+
+use crate::util::view::ArbiLikeView;
+use crate::{Arbi, Assign, Digit};
+
+#[derive(Debug, Copy, Clone)]
+pub enum BitwiseOp {
+    And,
+    Ior,
+    Xor,
+}
+
+#[inline]
+fn tcom_digit_of_neg_arg(digit: Digit, carry: &mut bool) -> Digit {
+    let (digit, overflow) = (!digit).overflowing_add(*carry as Digit);
+    *carry = overflow;
+    digit
+}
+
+#[inline]
+fn smag_digit_of_pos_res(
+    x_digit: Digit,
+    y_digit: Digit,
+    op: BitwiseOp,
+) -> Digit {
+    match op {
+        BitwiseOp::And => x_digit & y_digit,
+        BitwiseOp::Ior => x_digit | y_digit,
+        BitwiseOp::Xor => x_digit ^ y_digit,
+    }
+}
+
+#[inline]
+fn smag_digit_of_neg_res(
+    x_digit: Digit,
+    y_digit: Digit,
+    op: BitwiseOp,
+    carry: &mut bool,
+) -> Digit {
+    let (digit, overflow) = match op {
+        BitwiseOp::And => {
+            (!(x_digit & y_digit)).overflowing_add(*carry as Digit)
+        }
+        BitwiseOp::Ior => {
+            (!(x_digit | y_digit)).overflowing_add(*carry as Digit)
+        }
+        BitwiseOp::Xor => {
+            (!(x_digit ^ y_digit)).overflowing_add(*carry as Digit)
+        }
+    };
+    *carry = overflow;
+    digit
+}
+
+/*
+(1) x_size >= y_size.
+(2) Result is stored in self.
+(3) Exactly one of x_vec, y_vec can be self.vec, but neither of them is
+    perfectly acceptable too.
+*/
+macro_rules! bitwise_op_size_gte_impl {
+    ($self:expr, $x_vec:expr, $y_vec:expr, $x_size:expr, $y_size:expr, $x_neg:expr, $y_neg:expr, $op:expr) => {{
+        debug_assert!($x_vec.len() == $x_size);
+        debug_assert!($y_vec.len() == $y_size);
+        debug_assert!($x_size >= $y_size);
+        let z_is_neg: bool = match $op {
+            BitwiseOp::And => $x_neg & $y_neg,
+            BitwiseOp::Ior => $x_neg | $y_neg,
+            BitwiseOp::Xor => $x_neg ^ $y_neg,
+        };
+        let z_size: usize = match $op {
+            BitwiseOp::And => {
+                if $y_neg {
+                    $x_size
+                } else {
+                    $y_size
+                }
+            }
+            BitwiseOp::Ior => {
+                if $y_neg {
+                    $y_size
+                } else {
+                    $x_size
+                }
+            }
+            BitwiseOp::Xor => $x_size,
+        };
+        $self.vec.resize(z_size + (z_is_neg as usize), 0);
+        let carry = match ($x_neg, $y_neg) {
+            (false, false) => {
+                /* (x >= 0, y >= 0) ==> y bits are 00...0 in [$y_size, ...) */
+                for j in 0..$y_size {
+                    $self.vec[j] =
+                        smag_digit_of_pos_res($x_vec[j], $y_vec[j], $op);
+                }
+                for j in $y_size..z_size {
+                    $self.vec[j] = smag_digit_of_pos_res($x_vec[j], 0, $op);
+                }
+                false
+            }
+            (false, true) => {
+                /* (x >= 0, y < 0) ==> y bits are 11...1 in [$y_size, ...) */
+                let mut y_overflow = true;
+                match z_is_neg {
+                    true => {
+                        let mut z_overflow = true;
+                        for j in 0..$y_size {
+                            let y_digit = tcom_digit_of_neg_arg(
+                                $y_vec[j],
+                                &mut y_overflow,
+                            );
+                            $self.vec[j] = smag_digit_of_neg_res(
+                                $x_vec[j],
+                                y_digit,
+                                $op,
+                                &mut z_overflow,
+                            );
+                        }
+                        for j in $y_size..z_size {
+                            $self.vec[j] = smag_digit_of_neg_res(
+                                $x_vec[j],
+                                Digit::MAX,
+                                $op,
+                                &mut z_overflow,
+                            );
+                        }
+                        z_overflow
+                    }
+                    false => {
+                        for j in 0..$y_size {
+                            let y_digit = tcom_digit_of_neg_arg(
+                                $y_vec[j],
+                                &mut y_overflow,
+                            );
+                            $self.vec[j] =
+                                smag_digit_of_pos_res($x_vec[j], y_digit, $op);
+                        }
+                        for j in $y_size..z_size {
+                            $self.vec[j] = smag_digit_of_pos_res(
+                                $x_vec[j],
+                                Digit::MAX,
+                                $op,
+                            );
+                        }
+                        false
+                    }
+                }
+            }
+            (true, false) => {
+                /* (x < 0, y >= 0) ==> y bits are 00...0 in [$y_size, ...) */
+                let mut x_overflow = true;
+                match z_is_neg {
+                    true => {
+                        let mut z_overflow = true;
+                        for j in 0..$y_size {
+                            let x_digit = tcom_digit_of_neg_arg(
+                                $x_vec[j],
+                                &mut x_overflow,
+                            );
+                            $self.vec[j] = smag_digit_of_neg_res(
+                                x_digit,
+                                $y_vec[j],
+                                $op,
+                                &mut z_overflow,
+                            );
+                        }
+                        for j in $y_size..z_size {
+                            let x_digit = tcom_digit_of_neg_arg(
+                                $x_vec[j],
+                                &mut x_overflow,
+                            );
+                            $self.vec[j] = smag_digit_of_neg_res(
+                                x_digit,
+                                0,
+                                $op,
+                                &mut z_overflow,
+                            );
+                        }
+                        z_overflow
+                    }
+                    false => {
+                        for j in 0..$y_size {
+                            let x_digit = tcom_digit_of_neg_arg(
+                                $x_vec[j],
+                                &mut x_overflow,
+                            );
+                            $self.vec[j] =
+                                smag_digit_of_pos_res(x_digit, $y_vec[j], $op);
+                        }
+                        /* No second loop needed.
+                          And: since y >= 0, y_size applies.
+                          Ior: result sign is $x_neg | $y_neg, so z_is_neg is
+                               true.
+                          Xor: result sign is $x_neg ^ $y_neg, so z_is_neg is
+                               true.
+                        */
+                        false
+                    }
+                }
+            }
+            (true, true) => {
+                /* (x < 0, y < 0) ==> y bits are 11...1 in [$y_size, ...) */
+                let mut x_overflow = true;
+                let mut y_overflow = true;
+                match z_is_neg {
+                    true => {
+                        let mut z_overflow = true;
+                        for j in 0..$y_size {
+                            let x_digit = tcom_digit_of_neg_arg(
+                                $x_vec[j],
+                                &mut x_overflow,
+                            );
+                            let y_digit = tcom_digit_of_neg_arg(
+                                $y_vec[j],
+                                &mut y_overflow,
+                            );
+                            $self.vec[j] = smag_digit_of_neg_res(
+                                x_digit,
+                                y_digit,
+                                $op,
+                                &mut z_overflow,
+                            );
+                        }
+                        for j in $y_size..z_size {
+                            let x_digit = tcom_digit_of_neg_arg(
+                                $x_vec[j],
+                                &mut x_overflow,
+                            );
+                            $self.vec[j] = smag_digit_of_neg_res(
+                                x_digit,
+                                Digit::MAX,
+                                $op,
+                                &mut z_overflow,
+                            );
+                        }
+                        z_overflow
+                    }
+                    false => {
+                        for j in 0..$y_size {
+                            let x_digit = tcom_digit_of_neg_arg(
+                                $x_vec[j],
+                                &mut x_overflow,
+                            );
+                            let y_digit = tcom_digit_of_neg_arg(
+                                $y_vec[j],
+                                &mut y_overflow,
+                            );
+                            $self.vec[j] =
+                                smag_digit_of_pos_res(x_digit, y_digit, $op);
+                        }
+                        for j in $y_size..z_size {
+                            let x_digit = tcom_digit_of_neg_arg(
+                                $x_vec[j],
+                                &mut x_overflow,
+                            );
+                            $self.vec[j] =
+                                smag_digit_of_pos_res(x_digit, Digit::MAX, $op);
+                        }
+                        false
+                    }
+                }
+            }
+        };
+        if carry {
+            $self.vec[z_size] = 1;
+        } else {
+            $self.vec.truncate(z_size);
+        }
+        $self.neg = z_is_neg;
+        $self.trim();
+    }};
+}
+
+macro_rules! inplace_bitwise_op {
+    ($self:expr, $other:expr, $op:expr) => {{
+        let x_size: usize = $self.size();
+        let y_size: usize = $other.size();
+        if x_size >= y_size {
+            if $other.is_zero() {
+                if let BitwiseOp::And = $op {
+                    $self.make_zero();
+                }
+                return;
+            }
+            bitwise_op_size_gte_impl!(
+                $self, $self.vec, $other.vec, x_size, y_size, $self.neg,
+                $other.neg, $op
+            )
+        } else {
+            if $self.is_zero() {
+                if let BitwiseOp::Ior | BitwiseOp::Xor = $op {
+                    $self.assign($other);
+                }
+                return;
+            }
+            bitwise_op_size_gte_impl!(
+                $self, $other.vec, $self.vec, y_size, x_size, $other.neg,
+                $self.neg, $op
+            )
+        };
+    }};
+}
+
+impl Arbi {
+    pub(crate) fn inplace_bitwise_op(&mut self, other: &Arbi, op: BitwiseOp) {
+        inplace_bitwise_op!(self, other, op);
+    }
+
+    pub(crate) fn assign_bitwise_operation(
+        &mut self,
+        x: &Arbi,
+        y: &Arbi,
+        op: BitwiseOp,
+    ) {
+        let (x, y, x_size, y_size): (&Arbi, &Arbi, usize, usize) =
+            if x.size() < y.size() {
+                (y, x, y.size(), x.size())
+            } else {
+                (x, y, x.size(), y.size())
+            };
+        if y_size == 0 {
+            match op {
+                BitwiseOp::And => self.make_zero(),
+                _ => self.assign(x),
+            }
+            return;
+        }
+        bitwise_op_size_gte_impl!(
+            self, x.vec, y.vec, x_size, y_size, x.neg, y.neg, op
+        );
+    }
+
+    pub(crate) fn inplace_bitwise_op_with_arbi_like_view(
+        &mut self,
+        other: ArbiLikeView,
+        op: BitwiseOp,
+    ) {
+        inplace_bitwise_op!(self, other, op);
+    }
+
+    #[inline]
+    pub(crate) fn inplace_bitwise_and(&mut self, other: &Arbi) {
+        self.inplace_bitwise_op(other, BitwiseOp::And);
+    }
+
+    #[inline]
+    pub(crate) fn inplace_bitwise_ior(&mut self, other: &Arbi) {
+        self.inplace_bitwise_op(other, BitwiseOp::Ior);
+    }
+
+    #[inline]
+    pub(crate) fn inplace_bitwise_xor(&mut self, other: &Arbi) {
+        self.inplace_bitwise_op(other, BitwiseOp::Xor);
+    }
+
+    #[inline]
+    pub(crate) fn assign_bitwise_and(&mut self, a: &Arbi, b: &Arbi) {
+        self.assign_bitwise_operation(a, b, BitwiseOp::And)
+    }
+
+    #[inline]
+    pub(crate) fn assign_bitwise_ior(&mut self, a: &Arbi, b: &Arbi) {
+        self.assign_bitwise_operation(a, b, BitwiseOp::Ior)
+    }
+
+    #[inline]
+    pub(crate) fn assign_bitwise_xor(&mut self, a: &Arbi, b: &Arbi) {
+        self.assign_bitwise_operation(a, b, BitwiseOp::Xor)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::BitwiseOp;
+    use crate::util::test::{get_seedable_rng, get_uniform_die, Distribution};
+    use crate::{Arbi, DDigit, Digit};
+    use core::ops::RangeInclusive;
+
+    struct BitwiseTestCase {
+        name: &'static str,
+        lrng: RangeInclusive<i128>,
+        rrng: RangeInclusive<i128>,
+    }
+
+    fn test_bitwise_operation(
+        result: &mut Arbi,
+        r_1: i128,
+        r_2: i128,
+        op: BitwiseOp,
+    ) -> i128 {
+        let arbi_1 = Arbi::from(r_1);
+        let arbi_2 = Arbi::from(r_2);
+        match op {
+            BitwiseOp::And => {
+                let mut t_1 = Arbi::from(r_1);
+                let t_2 = Arbi::from(r_2);
+                t_1.inplace_bitwise_and(&t_2);
+                assert_eq!(t_1, r_1 & r_2);
+
+                result.assign_bitwise_and(&arbi_1, &arbi_2);
+                r_1 & r_2
+            }
+            BitwiseOp::Ior => {
+                let mut t_1 = Arbi::from(r_1);
+                let t_2 = Arbi::from(r_2);
+                t_1.inplace_bitwise_ior(&t_2);
+                assert_eq!(t_1, r_1 | r_2);
+
+                result.assign_bitwise_ior(&arbi_1, &arbi_2);
+                r_1 | r_2
+            }
+            BitwiseOp::Xor => {
+                let mut t_1 = Arbi::from(r_1);
+                let t_2 = Arbi::from(r_2);
+                t_1.inplace_bitwise_xor(&t_2);
+                assert_eq!(t_1, r_1 ^ r_2);
+
+                result.assign_bitwise_xor(&arbi_1, &arbi_2);
+                r_1 ^ r_2
+            }
+        }
+    }
+
+    #[test]
+    fn test_bitwise_operations() {
+        let test_cases = vec![
+            BitwiseTestCase {
+                name: "32-bit integers",
+                lrng: (i32::MIN as i128)..=(i32::MAX as i128),
+                rrng: (i32::MIN as i128)..=(i32::MAX as i128),
+            },
+            BitwiseTestCase {
+                name: "64-bit integers",
+                lrng: (i64::MIN as i128)..=(i64::MAX as i128),
+                rrng: (i64::MIN as i128)..=(i64::MAX as i128),
+            },
+            BitwiseTestCase {
+                name: "128-bit integers",
+                lrng: i128::MIN..=i128::MAX,
+                rrng: i128::MIN..=i128::MAX,
+            },
+            BitwiseTestCase {
+                name: "(32-bit LHS, 64-bit RHS)",
+                lrng: (i32::MIN as i128)..=(i32::MAX as i128),
+                rrng: (i64::MIN as i128)..=(i64::MAX as i128),
+            },
+            BitwiseTestCase {
+                name: "(Nonnegative 32-bit LHS, complete 64-bit RHS)",
+                lrng: 0..=(i32::MAX as i128),
+                rrng: (i64::MIN as i128)..=(i64::MAX as i128),
+            },
+            BitwiseTestCase {
+                name: "(Negative 32-bit LHS, complete 64-bit RHS)",
+                lrng: (i32::MIN as i128)..=-1,
+                rrng: (i64::MIN as i128)..=(i64::MAX as i128),
+            },
+            BitwiseTestCase {
+                name: "(Nonnegative 64-bit LHS, complete 128-bit RHS)",
+                lrng: 0..=(i64::MAX as i128),
+                rrng: i128::MIN..=i128::MAX,
+            },
+            BitwiseTestCase {
+                name: "(Negative 64-bit LHS, complete 128-bit RHS)",
+                lrng: (i64::MIN as i128)..=1,
+                rrng: i128::MIN..=i128::MAX,
+            },
+            BitwiseTestCase {
+                name: "(Nonnegative 32-bit LHS, complete 128-bit RHS)",
+                lrng: 0..=(i32::MAX as i128),
+                rrng: (i64::MIN as i128)..=(i64::MAX as i128),
+            },
+            BitwiseTestCase {
+                name: "(Negative 32-bit LHS, complete 128-bit RHS)",
+                lrng: (i32::MIN as i128)..=-1,
+                rrng: i128::MIN..=i128::MAX,
+            },
+        ];
+
+        let operations = [BitwiseOp::And, BitwiseOp::Ior, BitwiseOp::Xor];
+
+        let (mut rng, seed) = get_seedable_rng();
+        let mut result = Arbi::zero();
+
+        for test_case in test_cases {
+            let lhs_die =
+                get_uniform_die(*test_case.lrng.start(), *test_case.lrng.end());
+            let rhs_die =
+                get_uniform_die(*test_case.rrng.start(), *test_case.rrng.end());
+
+            for &op in &operations {
+                let test_name = format!(
+                    "{} with {:?} [LHS range: {}-{}, RHS range: {}-{}]",
+                    test_case.name,
+                    op,
+                    *test_case.lrng.start(),
+                    *test_case.lrng.end(),
+                    *test_case.rrng.start(),
+                    *test_case.rrng.end()
+                );
+
+                for _ in 0..i16::MAX {
+                    let r_1 = lhs_die.sample(&mut rng);
+                    let r_2 = rhs_die.sample(&mut rng);
+
+                    let expected =
+                        test_bitwise_operation(&mut result, r_1, r_2, op);
+
+                    assert_eq!(
+                        result, expected,
+                        "Failed {} test with LHS {}, RHS {}, and seed {}",
+                        test_name, r_1, r_2, seed
+                    );
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn test_bitwise_special_cases_and_patterns() {
+        let mut result = Arbi::zero();
+        let operations = [BitwiseOp::And, BitwiseOp::Ior, BitwiseOp::Xor];
+
+        let test_values = [
+            (0, "zero"),
+            (84, "small positive"),
+            (-84, "small negative"),
+            (-1, "all 1s"),
+            (-1_i128 >> 1, "-1 >> 1"),
+            (0x5555_5555_5555_5555_i128, "...010101"),
+            (0xAAAA_AAAA_AAAA_AAAA_i128, "...101010"),
+            (i32::MIN as i128, "32-bit min"),
+            (i32::MAX as i128, "32-bit max"),
+            (i64::MIN as i128, "64-bit min"),
+            (i64::MAX as i128, "64-bit max"),
+            (i128::MIN, "128-bit min"),
+            (i128::MAX, "128-bit max"),
+            (Digit::MAX as i128, "digit max"),
+            (DDigit::MAX as i128, "double digit max"),
+            (1_i128 << 31, "1 << 31"),
+            (1_i128 << 32, "1 << 32"),
+            (1_i128 << 63, "1 << 63"),
+            (1_i128 << 64, "1 << 64"),
+            (1_i128 << 127, "1 << 127"),
+            (0xFFFF_i128, "16 ones"),
+            (0xFFFF_FFFF_i128, "32 ones"),
+            (0xFFFF_FFFF_FFFF_FFFF_i128, "64 ones"),
+            (0xFFFF_FFFF_FFFF_FFFF_FFFF_FFFF_i128, "96 ones"),
+        ];
+
+        for (a, a_description) in test_values {
+            for (b, b_description) in test_values {
+                for &op in &operations {
+                    let expected =
+                        test_bitwise_operation(&mut result, a, b, op);
+                    assert_eq!(
+                        result, expected,
+                        "Failed special test with {} ({}) {:?} {} ({})",
+                        a_description, a, op, b_description, b
+                    );
+                }
+            }
+        }
+    }
+}

--- a/arbi/src/ops/bit/mod.rs
+++ b/arbi/src/ops/bit/mod.rs
@@ -1,0 +1,8 @@
+/*
+Copyright 2025 Owain Davies
+SPDX-License-Identifier: Apache-2.0 OR MIT
+*/
+
+mod arbi_x_arbi;
+mod arbi_x_int;
+mod impls;

--- a/arbi/src/ops/mod.rs
+++ b/arbi/src/ops/mod.rs
@@ -1,0 +1,6 @@
+/*
+Copyright 2025 Owain Davies
+SPDX-License-Identifier: Apache-2.0 OR MIT
+*/
+
+mod bit;

--- a/arbi/src/right_shift.rs
+++ b/arbi/src/right_shift.rs
@@ -3,7 +3,7 @@ Copyright 2024-2025 Owain Davies
 SPDX-License-Identifier: Apache-2.0 OR MIT
 */
 
-use crate::macros::for_all_integers;
+use crate::macros::for_all_ints;
 use crate::{Arbi, BitCount, Digit};
 use core::ops::{Shr, ShrAssign};
 
@@ -206,7 +206,7 @@ impl ShrAssign<&$bitcount> for Arbi {
 }
 /* impl_shr_integral! */
 
-for_all_integers!(impl_shr_integral);
+for_all_ints!(impl_shr_integral);
 
 #[cfg(test)]
 mod test_arithmetic_rshift {

--- a/arbi/src/util/arbi_like_array.rs
+++ b/arbi/src/util/arbi_like_array.rs
@@ -1,0 +1,151 @@
+/*
+Copyright 2025 Owain Davies
+SPDX-License-Identifier: Apache-2.0 OR MIT
+*/
+
+use crate::macros::for_all_ints_with_metadata;
+use crate::Digit;
+use core::ops::Shr;
+
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct ArbiLikeArray<const N: usize> {
+    digits: [Digit; N],
+    length: usize,
+    is_neg: bool,
+}
+
+#[allow(dead_code)]
+pub(crate) trait IntoArbiLikeArray<const N: usize> {
+    fn into_arbi_like_array(self) -> ArbiLikeArray<N>;
+}
+
+impl<const N: usize> ArbiLikeArray<N> {
+    #[allow(dead_code)]
+    #[inline(always)]
+    pub(crate) fn digits(&self) -> &[Digit] {
+        &self.digits[..self.length]
+    }
+
+    #[allow(dead_code)]
+    #[inline(always)]
+    pub(crate) fn length(&self) -> usize {
+        self.length
+    }
+
+    #[allow(dead_code)]
+    #[inline(always)]
+    pub(crate) fn is_negative(&self) -> bool {
+        self.is_neg
+    }
+}
+
+/* !impl_into_arbi_like_array */
+macro_rules! impl_into_arbi_like_array {
+    ($(($int:ty, $uint:ty, $max_size:expr)),*) => {
+        $(
+
+impl IntoArbiLikeArray<$max_size> for $int {
+    #[allow(unused_comparisons)]
+    fn into_arbi_like_array(self) -> ArbiLikeArray<$max_size> {
+        if self == 0 {
+            return ArbiLikeArray {
+                digits: [0; $max_size],
+                length: 0,
+                is_neg: false,
+            };
+        }
+        let is_neg = self < 0;
+        let mut value = if is_neg {
+            (0 as $uint).wrapping_sub(self as $uint)
+        } else {
+            self as $uint
+        };
+        if Digit::BITS >= <$uint>::BITS {
+            ArbiLikeArray {
+                digits: [value as Digit; $max_size],
+                length: 1,
+                is_neg,
+            }
+        } else {
+            let mut digits = [0 as Digit; $max_size];
+            let mut length = 0;
+            while value != 0 {
+                digits[length] = (value & (Digit::MAX as $uint)) as Digit;
+                // value >>= Digit::BITS;
+                value = value.shr(Digit::BITS); // For MSRV
+                length += 1;
+            }
+            ArbiLikeArray {
+                digits,
+                length,
+                is_neg,
+            }
+        }
+    }
+}
+
+        )*
+    };
+}
+/* impl_into_arbi_like_array! */
+
+for_all_ints_with_metadata!(impl_into_arbi_like_array);
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_zero() {
+        let x: i32 = 0;
+        let stack = x.into_arbi_like_array();
+        assert_eq!(stack.length(), 0);
+        assert_eq!(stack.is_negative(), false);
+        assert!(stack.digits().is_empty());
+    }
+
+    #[test]
+    fn test_positive() {
+        let x: i32 = 42;
+        let stack = x.into_arbi_like_array();
+        assert_eq!(stack.length(), 1);
+        assert_eq!(stack.is_negative(), false);
+        assert_eq!(stack.digits(), &[42]);
+    }
+
+    #[test]
+    fn test_negative() {
+        let x: i32 = -42;
+        let stack = x.into_arbi_like_array();
+        assert_eq!(stack.length(), 1);
+        assert_eq!(stack.is_negative(), true);
+        assert_eq!(stack.digits(), &[42]);
+    }
+
+    #[test]
+    fn test_large_unsigned() {
+        let x: u64 = 0xFFFF_FFFF_0000_0000;
+        let stack = x.into_arbi_like_array();
+        assert_eq!(stack.length(), 2);
+        assert_eq!(stack.is_negative(), false);
+        assert_eq!(stack.digits(), &[0, 0xFFFF_FFFF]);
+    }
+}
+
+/* !impl_from_int */
+macro_rules! impl_from_int {
+    ($(($int:ty, $uint:ty, $max_size:expr)),*) => {
+        $(
+
+impl From<$int> for ArbiLikeArray<$max_size> {
+    fn from(value: $int) -> Self {
+        value.into_arbi_like_array()
+    }
+}
+
+        )*
+    };
+ }
+/* impl_from_int! */
+
+for_all_ints_with_metadata!(impl_from_int);

--- a/arbi/src/util/max_digits.rs
+++ b/arbi/src/util/max_digits.rs
@@ -1,0 +1,50 @@
+/*
+Copyright 2025 Owain Davies
+SPDX-License-Identifier: Apache-2.0 OR MIT
+*/
+
+#[allow(dead_code)]
+pub(crate) const fn max_digits<T>() -> usize {
+    use crate::uints::div_ceil_usize;
+    use crate::Digit;
+
+    div_ceil_usize(
+        core::mem::size_of::<T>().checked_mul(8).unwrap(),
+        Digit::BITS as usize,
+    )
+}
+
+#[cfg(test)]
+mod test_max_digits {
+    use super::max_digits;
+    use crate::Digit;
+
+    #[test]
+    fn test_max_digits() {
+        if Digit::BITS == 32 {
+            assert_eq!(max_digits::<i8>(), 1);
+            assert_eq!(max_digits::<i16>(), 1);
+            assert_eq!(max_digits::<i32>(), 1);
+            assert_eq!(max_digits::<i64>(), 2);
+            assert_eq!(max_digits::<i128>(), 4);
+
+            assert_eq!(max_digits::<u8>(), 1);
+            assert_eq!(max_digits::<u16>(), 1);
+            assert_eq!(max_digits::<u32>(), 1);
+            assert_eq!(max_digits::<u64>(), 2);
+            assert_eq!(max_digits::<u128>(), 4);
+        } else if Digit::BITS == 64 {
+            assert_eq!(max_digits::<i8>(), 1);
+            assert_eq!(max_digits::<i16>(), 1);
+            assert_eq!(max_digits::<i32>(), 1);
+            assert_eq!(max_digits::<i64>(), 1);
+            assert_eq!(max_digits::<i128>(), 2);
+
+            assert_eq!(max_digits::<u8>(), 1);
+            assert_eq!(max_digits::<u16>(), 1);
+            assert_eq!(max_digits::<u32>(), 1);
+            assert_eq!(max_digits::<u64>(), 1);
+            assert_eq!(max_digits::<u128>(), 2);
+        }
+    }
+}

--- a/arbi/src/util/max_digits.rs
+++ b/arbi/src/util/max_digits.rs
@@ -7,11 +7,7 @@ SPDX-License-Identifier: Apache-2.0 OR MIT
 pub(crate) const fn max_digits<T>() -> usize {
     use crate::uints::div_ceil_usize;
     use crate::Digit;
-
-    div_ceil_usize(
-        core::mem::size_of::<T>().checked_mul(8).unwrap(),
-        Digit::BITS as usize,
-    )
+    div_ceil_usize(core::mem::size_of::<T>() * 8, Digit::BITS as usize)
 }
 
 #[cfg(test)]

--- a/arbi/src/util/mod.rs
+++ b/arbi/src/util/mod.rs
@@ -1,9 +1,17 @@
 /*
-Copyright 2024 Owain Davies
+Copyright 2024-2025 Owain Davies
 SPDX-License-Identifier: Apache-2.0 OR MIT
 */
 
+pub(crate) mod arbi_like_array;
+pub(crate) mod max_digits;
 /// Utilities for testing.
 #[cfg(test)]
 pub(crate) mod test;
 pub(crate) mod to_digits;
+pub(crate) mod view;
+
+pub(crate) use arbi_like_array::{ArbiLikeArray, IntoArbiLikeArray};
+pub(crate) use max_digits::max_digits;
+#[allow(unused_imports)]
+pub(crate) use view::ArbiLikeView;

--- a/arbi/src/util/to_digits.rs
+++ b/arbi/src/util/to_digits.rs
@@ -3,6 +3,8 @@ Copyright 2024 Owain Davies
 SPDX-License-Identifier: Apache-2.0 OR MIT
 */
 
+/* TODO: Use StackDigits instead. */
+
 use crate::Digit;
 use core::ops::Shr;
 

--- a/arbi/src/util/view.rs
+++ b/arbi/src/util/view.rs
@@ -1,0 +1,69 @@
+/*
+Copyright 2025 Owain Davies
+SPDX-License-Identifier: Apache-2.0 OR MIT
+*/
+
+use crate::util::ArbiLikeArray;
+use crate::{Arbi, Assign, Digit};
+
+pub(crate) struct ArbiLikeView<'a> {
+    pub(crate) vec: &'a [Digit],
+    pub(crate) neg: bool,
+}
+
+// TODO: trait for copied methods?
+impl ArbiLikeView<'_> {
+    #[allow(dead_code)]
+    #[inline(always)]
+    pub(crate) fn size(&self) -> usize {
+        self.vec.len()
+    }
+
+    #[allow(dead_code)]
+    #[inline(always)]
+    pub(crate) fn is_negative(&self) -> bool {
+        self.neg
+    }
+
+    #[allow(dead_code)]
+    #[inline(always)]
+    pub(crate) fn is_zero(&self) -> bool {
+        self.vec.is_empty()
+    }
+}
+
+impl Assign<ArbiLikeView<'_>> for Arbi {
+    #[inline(always)]
+    fn assign(&mut self, value: ArbiLikeView) {
+        self.assign_slice(value.vec, value.neg);
+    }
+}
+
+impl Arbi {
+    #[allow(dead_code)]
+    #[inline(always)]
+    pub(crate) fn as_arbi_like_view(&self) -> ArbiLikeView {
+        ArbiLikeView {
+            vec: &self.vec,
+            neg: self.neg,
+        }
+    }
+}
+
+impl<'a, const N: usize> From<&'a ArbiLikeArray<N>> for ArbiLikeView<'a> {
+    fn from(arbi_like: &'a ArbiLikeArray<N>) -> Self {
+        ArbiLikeView {
+            vec: arbi_like.digits(),
+            neg: arbi_like.is_negative(),
+        }
+    }
+}
+
+impl<'a> From<&'a Arbi> for ArbiLikeView<'a> {
+    fn from(arbi: &'a Arbi) -> Self {
+        ArbiLikeView {
+            vec: &arbi.vec,
+            neg: arbi.is_negative(),
+        }
+    }
+}


### PR DESCRIPTION
In the previous implementation, temporaries involving memory allocation were created for negative operands to store their two's complement representation. Then, bitwise operations were applied digit-wise. This meant that a bitwise operation could have up to 3 memory allocations/reallocations in one call.

In this PR, we imitate two's complement on-the-fly, avoiding the need for the temporaries, thereby limiting each operation to at most 1 allocation/reallocation.

A reallocation/allocation will be needed if there is not enough capacity in existing buffers or when there are only immutable references to buffers available to the operation. For the latter case, the implementation already supports assigning the result of a bitwise operation involving immutable references to an existing buffer, thereby avoiding the need for additional allocations, but an *API to express such a case has not yet been decided*.

Moreover, bitwise operations (`&`, `|`, `^`) between `Arbi` integers and primitive integer types like `i8`,...,`i128` are now supported.
