### PR TITLE
Make set of valid strings for `from_str_radix()` consistent with primitives

### DIFF
--- a/arbi/src/assign_string.rs
+++ b/arbi/src/assign_string.rs
@@ -1,15 +1,23 @@
 /*
-Copyright 2024 Owain Davies
+Copyright 2024-2025 Owain Davies
 SPDX-License-Identifier: Apache-2.0 OR MIT
 */
 
-use crate::from_string::ParseError;
-use crate::Arbi;
+use crate::from_string::{configs::BASE_MBS, BaseMbs, ParseError};
+use crate::uints::UnsignedUtilities;
 use crate::Base;
+use crate::{Arbi, Digit};
 
 impl Arbi {
     /// Assign the integer value the provided string represents to this `Arbi`
     /// integer.
+    ///
+    /// <div class="warning">
+    ///
+    /// If a parsing error is returned, `self`'s value may be different from its
+    /// original.
+    ///
+    /// </div>
     ///
     /// # Panic
     /// Panics if `radix` is not in \\( [2, 36] \\). Use
@@ -25,38 +33,18 @@ impl Arbi {
     /// match x.assign_str_radix("123456789", 10) {
     ///     Ok(_) => assert_eq!(x, 123456789),
     ///     Err(e) => match e {
-    ///         ParseError::InvalidDigit => panic!("Found an invalid digit"),
-    ///         ParseError::Empty => panic!("Found an empty string"),
+    ///         ParseError::InvalidDigit => panic!("invalid digit"),
+    ///         ParseError::Empty => panic!("empty string"),
     ///     },
     /// }
     ///
-    /// if let Err(e) = x.assign_str_radix("7c2ecdfacad74e0f0101b", 16) {
-    ///     panic!("Parsing error: {}", e);
-    /// }
+    /// x.assign_str_radix("7c2ecdfacad74e0f0101b", 16).unwrap();
     /// assert_eq!(x, 0x7c2ecdfacad74e0f0101b_u128);
-    /// ```
-    ///
-    /// The `Arbi` integer will remain in its original state if a parsing error
-    /// occurs:
-    /// ```
-    /// use arbi::{Arbi, Assign, ParseError};
-    ///
-    /// let mut x = Arbi::from(u128::MAX);
-    /// assert_eq!(x, u128::MAX);
-    ///
-    /// match x.assign_str_radix("7c2ecdfacad74e0f0101b", 15) {
-    ///     Ok(_) => panic!(),
-    ///     Err(e) => {
-    ///         assert!(matches!(e, ParseError::InvalidDigit));
-    ///         assert_eq!(x, u128::MAX);
-    ///     }
-    /// }
     /// ```
     ///
     /// Panics on invalid `radix` values
     /// ```should_panic
     /// use arbi::Arbi;
-    ///
     /// let mut x = Arbi::with_capacity(5);
     /// x.assign_str_radix("7c2ecdfacad74e0f0101b", 37);
     /// ```
@@ -67,9 +55,10 @@ impl Arbi {
     ///
     /// let mut a = Arbi::zero();
     ///
+    /// assert!(matches!(a.assign_str_radix("", 10), Err(ParseError::Empty)));
     /// assert!(matches!(
     ///     a.assign_str_radix("   - ", 10),
-    ///     Err(ParseError::Empty)
+    ///     Err(ParseError::InvalidDigit)
     /// ));
     /// assert!(matches!(
     ///     a.assign_str_radix("ffff", 10),
@@ -85,12 +74,18 @@ impl Arbi {
             Ok(b) => b,
             Err(_) => panic!("Invalid radix {}", radix),
         };
-
-        self.from_str_base_inplace(s, base)
+        self.assign_str_base(s, base)
     }
 
     /// Assign the integer value the provided string represents to this `Arbi`
     /// integer.
+    ///
+    /// <div class="warning">
+    ///
+    /// If a parsing error is returned, `self`'s value may be different from its
+    /// original.
+    ///
+    /// </div>
     ///
     /// # Examples
     /// ```
@@ -105,34 +100,13 @@ impl Arbi {
     /// match x.assign_str_base("123456789", DEC) {
     ///     Ok(_) => assert_eq!(x, 123456789),
     ///     Err(e) => match e {
-    ///         ParseError::InvalidDigit => panic!("Found an invalid digit"),
-    ///         ParseError::Empty => panic!("Found an empty string"),
+    ///         ParseError::InvalidDigit => panic!("invalid digit"),
+    ///         ParseError::Empty => panic!("empty string"),
     ///     },
     /// }
     ///
-    /// if let Err(e) = x.assign_str_base("7c2ecdfacad74e0f0101b", HEX) {
-    ///     panic!("Parsing error: {}", e);
-    /// }
+    /// x.assign_str_base("7c2ecdfacad74e0f0101b", HEX).unwrap();
     /// assert_eq!(x, 0x7c2ecdfacad74e0f0101b_u128);
-    /// ```
-    ///
-    /// The `Arbi` integer will remain in its original state if a parsing error
-    /// occurs:
-    /// ```
-    /// use arbi::{Arbi, Base, ParseError};
-    ///
-    /// let mut x = Arbi::from(u128::MAX);
-    /// assert_eq!(x, u128::MAX);
-    ///
-    /// match x
-    ///     .assign_str_base("7c2ecdfacad74e0f0101b", Base::try_from(15).unwrap())
-    /// {
-    ///     Ok(_) => panic!(),
-    ///     Err(e) => {
-    ///         assert!(matches!(e, ParseError::InvalidDigit));
-    ///         assert_eq!(x, u128::MAX);
-    ///     }
-    /// }
     /// ```
     ///
     /// Example invalid strings:
@@ -141,9 +115,10 @@ impl Arbi {
     ///
     /// let mut a = Arbi::zero();
     ///
+    /// assert!(matches!(a.assign_str_base("", DEC), Err(ParseError::Empty)));
     /// assert!(matches!(
     ///     a.assign_str_base("   - ", DEC),
-    ///     Err(ParseError::Empty)
+    ///     Err(ParseError::InvalidDigit)
     /// ));
     /// assert!(matches!(
     ///     a.assign_str_base("ffff", DEC),
@@ -155,7 +130,129 @@ impl Arbi {
         s: &str,
         base: Base,
     ) -> Result<(), ParseError> {
-        self.from_str_base_inplace(s, base)
+        let (base_digits, has_minus_sign) =
+            Self::parse_str_sign_skip_leading_zeros(s)?;
+        if base_digits.is_empty() {
+            self.make_zero();
+            return Ok(());
+        }
+
+        // Get configuration for this base
+        let base_val = base.value() as u32;
+        let BaseMbs { mbs, base_pow_mbs } = BASE_MBS[base_val as usize];
+
+        // Reserve estimated capacity
+        let estimate = usize::div_ceil_(base_digits.len(), mbs);
+        self.vec
+            .reserve(estimate.saturating_sub(self.vec.capacity()));
+        self.vec.clear();
+        self.neg = has_minus_sign;
+
+        #[cfg(debug_assertions)]
+        let initial_capacity = self.vec.capacity();
+
+        let n_base = base_digits.len();
+        let rem_batch_size = n_base % mbs;
+        let mut pos = 0;
+
+        /* Handle first partial chunk */
+        if rem_batch_size > 0 {
+            // Initialize batch value
+            let mut batch: Digit = 0;
+            // Convert batch substring to integer value
+            let end = pos + rem_batch_size;
+            while pos < end {
+                match (base_digits[pos] as char).to_digit(base_val) {
+                    Some(digit) => {
+                        batch = digit + batch * base_val;
+                        pos += 1;
+                    }
+                    None => return Err(ParseError::InvalidDigit),
+                }
+            }
+            debug_assert!(batch != 0);
+            self.vec.push(batch);
+        }
+
+        /* Process remaining full-size chunks */
+        while pos < n_base {
+            // Initialize batch value
+            let mut batch: Digit = 0;
+            // Convert batch substring to integer value
+            let end = pos + mbs;
+            while pos < end {
+                match (base_digits[pos] as char).to_digit(base_val) {
+                    Some(digit) => {
+                        batch = digit + batch * base_val;
+                        pos += 1;
+                    }
+                    None => return Err(ParseError::InvalidDigit),
+                }
+            }
+            Self::imul1add1(self, base_pow_mbs, Some(batch));
+        }
+
+        #[cfg(debug_assertions)]
+        debug_assert_eq!(self.vec.capacity(), initial_capacity);
+
+        self.trim();
+        Ok(())
+    }
+
+    pub(crate) fn parse_str_sign(s: &str) -> Result<(&[u8], bool), ParseError> {
+        if s.is_empty() {
+            return Err(ParseError::Empty);
+        }
+
+        let s = s.as_bytes();
+
+        let (base_digits, has_minus_sign) = match s {
+            [b'-' | b'+'] => {
+                return Err(ParseError::InvalidDigit);
+            }
+            [b'-', rest @ ..] => (rest, true),
+            [b'+', rest @ ..] => (rest, false),
+            _ => (s, false),
+        };
+        debug_assert!(!base_digits.is_empty());
+
+        Ok((base_digits, has_minus_sign))
+    }
+
+    pub(crate) fn parse_str_sign_skip_leading_zeros(
+        s: &str,
+    ) -> Result<(&[u8], bool), ParseError> {
+        let (mut base_digits, has_minus_sign) = Self::parse_str_sign(s)?;
+        while let [c, rest @ ..] = base_digits {
+            if *c != b'0' {
+                break;
+            }
+            base_digits = rest;
+        }
+        Ok((base_digits, has_minus_sign))
+    }
+
+    #[allow(dead_code)]
+    pub(crate) fn validate_str_base(
+        s: &str,
+        base: Base,
+    ) -> Result<(&[u8], bool), ParseError> {
+        let (mut base_digits, has_minus_sign) = Self::parse_str_sign(s)?;
+
+        let base: u32 = base.value() as u32;
+
+        while let [c, rest @ ..] = base_digits {
+            let _ = match (*c as char).to_digit(base) {
+                Some(value) => value,
+                None => {
+                    return Err(ParseError::InvalidDigit);
+                }
+            };
+
+            base_digits = rest;
+        }
+
+        Ok((base_digits, has_minus_sign))
     }
 }
 


### PR DESCRIPTION
In this PR, we change what constitutes a valid string slice in `from_str_radix()`, `assign_str_radix()`, `from_str_base()`, and `assign_str_base()` functions so that it is consistent with the string slice expected by `from_str_radix()` for primitive integer types (e.g. `i32::from_str_radix()`).

This is a **BREAKING** change, as previously, among other things, leading and trailing whitespace was permitted.

Moreover, `assign_str_radix()` and `assign_str_base()` functions no longer maintain the guarantee that the original value will remain intact if a parsing error occurs. In particular, these functions no longer validate the entire string before assigning to the arbitrary precision integer's underlying buffer. A **warning** has been issued in their respective documentation. This is also a **BREAKING** change.

Finally, we make from/assign string code much more maintainable by basing all functions on a single implementation: `assign_str_base()`.

There is no performance degradation. 