### PR TITLE
Optimize from/assign str for power of 2 bases

### DIFF
--- a/arbi/scripts/size_in_radix.py
+++ b/arbi/scripts/size_in_radix.py
@@ -1,0 +1,50 @@
+###############################################################################
+# Copyright 2025 Owain Davies
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+#
+# This file is part of "arbi", an Arbitrary Precision Integer library for Rust.
+###############################################################################
+
+from decimal import getcontext, Decimal, ROUND_CEILING
+
+# Some high enough precision :)
+getcontext().prec = 100
+
+
+# ceil( (log(2) / log(base)) * 2^(digit_bits) )
+# Useful for computing the needed capacity for Arbi::to_string()-type functions
+def log2_div_logb(base: int, digit_bits: int = 32) -> int:
+    x = Decimal(2).ln() / Decimal(base).ln()
+    scaled = x * Decimal(1 << digit_bits)
+
+    return int(scaled.to_integral_exact(ROUND_CEILING))
+
+
+# ceil( (log(base) / log(2^(digit_bits))) * 2^(digit_bits) )
+# Useful for computing the needed capacity for Arbi::from_str()-type functions
+def logb_div_logab(base: int, digit_bits: int = 32) -> int:
+    x = Decimal(base).ln() / Decimal(1 << digit_bits).ln()
+    scaled = x * Decimal(1 << digit_bits)
+
+    return int(scaled.to_integral_exact(ROUND_CEILING))
+
+
+def print_arrays():
+    def print_array(prefix: str, digit_bits: int, func, start_base: int):
+        print(f"const {prefix}_{digit_bits}: [u{digit_bits}; 37] = [")
+
+        max_hex_digits = digit_bits >> 2
+        for base in range(start_base):  # Use 0 for bases [0, start_base)
+            print(f"{' ' * 4}0x{'0' * max_hex_digits},")
+        for base in range(start_base, 37):
+            print(f"{' ' * 4}0x{func(base, digit_bits):x},")
+
+        print("];\n")
+
+    for digit_bits in (32, 64):
+        print_array("SCALED_LOG2_DIV_LOG", digit_bits, log2_div_logb, 3)
+        print_array("SCALED_LOGB_DIV_LOGAB", digit_bits, logb_div_logab, 2)
+
+
+if __name__ == "__main__":
+    print_arrays()

--- a/arbi/src/multiplication.rs
+++ b/arbi/src/multiplication.rs
@@ -26,7 +26,7 @@ impl Arbi {
     ///
     /// ## Complexity
     /// \\( O(n) \\)
-    #[allow(dead_code)]
+    #[inline(always)]
     pub(crate) fn imul1add1(x: &mut Self, v: Digit, k: Option<Digit>) {
         let mut k: Digit = k.unwrap_or(0);
         for d in &mut x.vec {

--- a/arbi/src/size.rs
+++ b/arbi/src/size.rs
@@ -16,13 +16,10 @@ impl Arbi {
     /// # Examples
     /// ```
     /// use arbi::{Arbi, Digit};
-    ///
     /// let zero = Arbi::zero();
     /// assert_eq!(zero.size(), 0);
-    ///
     /// let mut a = Arbi::from(Digit::MAX);
     /// assert_eq!(a.size(), 1);
-    ///
     /// a += 1;
     /// assert_eq!(a.size(), 2);
     /// ```
@@ -42,10 +39,8 @@ impl Arbi {
     /// # Examples
     /// ```
     /// use arbi::{Arbi, BitCount, Digit};
-    ///
     /// let zero = Arbi::zero();
     /// assert_eq!(zero.size_bits(), 0);
-    ///
     /// let mut a = Arbi::from(Digit::MAX);
     /// assert_eq!(a.size_bits(), Digit::BITS as BitCount);
     /// a += 1;
@@ -106,15 +101,12 @@ impl Arbi {
     /// # Examples
     /// ```
     /// use arbi::Arbi;
-    ///
     /// let mut zero = Arbi::zero();
     /// assert_eq!(zero.size_base_mut(10), 0);
     /// assert_eq!(zero, 0);
-    ///
     /// let mut one = Arbi::one();
     /// assert_eq!(one.size_base_mut(10), 1);
     /// assert_eq!(one, 1);
-    ///
     /// let mut a = Arbi::from_str_radix("123456789", 10).unwrap();
     /// assert_eq!(a.size_base_mut(10), 9);
     /// assert_eq!(a, 9);
@@ -148,13 +140,10 @@ impl Arbi {
     /// # Examples
     /// ```
     /// use arbi::Arbi;
-    ///
     /// let zero = Arbi::zero();
     /// assert_eq!(zero.size_base_ref(10), 0);
-    ///
     /// let one = Arbi::one();
     /// assert_eq!(one.size_base_ref(10), 1);
-    ///
     /// let a = Arbi::from_str_radix("123456789", 10).unwrap();
     /// assert_eq!(a.size_base_ref(10), 9);
     /// ```
@@ -176,7 +165,7 @@ impl Arbi {
 
     pub(crate) fn size_radix_no_check(&mut self, base: u32) -> BitCount {
         let mut count: BitCount = 0;
-        while self > 0 {
+        while self.size() != 0 {
             Self::div_algo_digit_inplace(self, base as Digit);
             count += 1;
         }
@@ -192,7 +181,6 @@ impl Arbi {
         }
         if base.is_power_of_two() {
             let bit_length = self.size_bits();
-            // let base_log2 = base.ilog2();
             let base_log2 = u32::ilog2_(base);
             return Some(BitCount::div_ceil_(
                 bit_length,

--- a/arbi/src/util/mul.rs
+++ b/arbi/src/util/mul.rs
@@ -3,95 +3,185 @@ Copyright 2025 Owain Davies
 SPDX-License-Identifier: Apache-2.0 OR MIT
 */
 
-macro_rules! define_mul2 {
-    // mul2(), mul2_halves() implement
-    //
-    //      a * b -> (hi, lo)
-    //
-    //      where a, b, hi, lo are all of type uint.
-    //
-    // They are equivalent in behavior.
-    //
-    // uint     : primitive unsigned integer type (e.g. u128).
-    // uint_h   : primitive unsigned integer type with size in bits half that
-    //            of uint.
-    ($uint:ty, $uint_h:ty) => {
+macro_rules! define_mul2_internal {
+    // Internal macro that defines the common parts
+    ($uint:ty) => {
+        const UINT_BITS: u32 = <$uint>::BITS;
+        const UINT_H_BITS: u32 = UINT_BITS >> 1;
+        const UINT_H_BASE: $uint = 1 as $uint << UINT_H_BITS;
+        const UINT_H_MAX: $uint = UINT_H_BASE - 1;
 
-const UINT_BITS: u32 = <$uint>::BITS;
-const UINT_H_BITS: u32 = UINT_BITS >> 1;
-const UINT_H_BASE: $uint = 1 as $uint << UINT_H_BITS;
-const UINT_H_MAX: $uint = UINT_H_BASE - 1; // MASK for low part of UINT
+        #[inline(always)]
+        #[allow(dead_code)]
+        const fn split_uint(x: $uint) -> ($uint, $uint) {
+            let hi = x >> UINT_H_BITS;
+            let lo = x & UINT_H_MAX;
+            (hi, lo)
+        }
 
-#[inline(always)]
-#[allow(dead_code)]
-const fn split_uint(x: $uint) -> ($uint, $uint) {
-    let hi = x >> UINT_H_BITS;
-    let lo = x & UINT_H_MAX;
-    (hi, lo)
-}
+        #[inline]
+        #[allow(dead_code)]
+        pub(crate) const fn mul2(a: $uint, b: $uint) -> ($uint, $uint) {
+            let (a_hi, a_lo) = split_uint(a);
+            let (b_hi, b_lo) = split_uint(b);
 
-#[inline(always)]
-const fn split_uint_halves(x: $uint) -> ($uint_h, $uint_h) {
-    let hi = (x >> UINT_H_BITS) as $uint_h;
-    let lo = (x & UINT_H_MAX) as $uint_h;
-    (hi, lo)
-}
+            let mut ahbh = a_hi * b_hi;
+            let ahbl = a_hi * b_lo;
+            let mut albh = a_lo * b_hi;
+            let albl = a_lo * b_lo;
 
-#[inline]
-#[allow(dead_code)]
-pub(crate) const fn mul2(a: $uint, b: $uint) -> ($uint, $uint) {
-    let (a_hi, a_lo) = split_uint(a);
-    let (b_hi, b_lo) = split_uint(b);
+            let (albl_hi, albl_lo) = split_uint(albl);
 
-    let mut ahbh = a_hi * b_hi;
-    let ahbl = a_hi * b_lo;
-    let mut albh = a_lo * b_hi;
-    let albl = a_lo * b_lo;
+            albh += albl_hi;
+            debug_assert!(albh >= albl_hi);
 
-    let (albl_hi, albl_lo) = split_uint(albl);
+            let (albh, overflow) = albh.overflowing_add(ahbl);
+            if overflow {
+                ahbh = ahbh.wrapping_add(UINT_H_BASE);
+            }
 
-    albh += albl_hi;
-    debug_assert!(albh >= albl_hi);
-
-    let (albh, overflow) = albh.overflowing_add(ahbl);
-    if overflow {
-        ahbh = ahbh.wrapping_add(UINT_H_BASE);
-    }
-
-    (
-        ahbh.wrapping_add(albh >> UINT_H_BITS),
-        albl_lo.wrapping_add(albh << UINT_H_BITS),
-    )
-}
-
-#[inline]
-pub(crate) const fn mul2_halves(a: $uint, b: $uint) -> ($uint, $uint) {
-    let (a_hi, a_lo) = split_uint_halves(a);
-    let (b_hi, b_lo) = split_uint_halves(b);
-
-    let mut ahbh: $uint = (a_hi as $uint) * (b_hi as $uint);
-    let ahbl: $uint = (a_hi as $uint) * (b_lo as $uint);
-    let mut albh: $uint = (a_lo as $uint) * (b_hi as $uint);
-    let albl: $uint = (a_lo as $uint) * (b_lo as $uint);
-
-    let (albl_hi, albl_lo) = split_uint_halves(albl);
-
-    albh += albl_hi as $uint;
-    debug_assert!(albh >= albl_hi as $uint);
-
-    let (albh, overflow) = albh.overflowing_add(ahbl);
-    if overflow {
-        ahbh = ahbh.wrapping_add(UINT_H_BASE);
-    }
-
-    (
-        ahbh.wrapping_add(albh >> UINT_H_BITS),
-        (albl_lo as $uint).wrapping_add(albh << UINT_H_BITS),
-    )
-}
-
+            (
+                ahbh.wrapping_add(albh >> UINT_H_BITS),
+                albl_lo.wrapping_add(albh << UINT_H_BITS),
+            )
+        }
     };
 }
+
+macro_rules! define_mul2 {
+    // Single parameter version - only defines mul2()
+    ($uint:ty) => {
+        define_mul2_internal!($uint);
+    };
+
+    // Two parameter version - adds mul2_halves()
+    ($uint:ty, $uint_h:ty) => {
+        define_mul2_internal!($uint);
+
+        #[inline(always)]
+        const fn split_uint_halves(x: $uint) -> ($uint_h, $uint_h) {
+            let hi = (x >> UINT_H_BITS) as $uint_h;
+            let lo = (x & UINT_H_MAX) as $uint_h;
+            (hi, lo)
+        }
+
+        #[inline]
+        pub(crate) const fn mul2_halves(a: $uint, b: $uint) -> ($uint, $uint) {
+            let (a_hi, a_lo) = split_uint_halves(a);
+            let (b_hi, b_lo) = split_uint_halves(b);
+
+            let mut ahbh: $uint = (a_hi as $uint) * (b_hi as $uint);
+            let ahbl: $uint = (a_hi as $uint) * (b_lo as $uint);
+            let mut albh: $uint = (a_lo as $uint) * (b_hi as $uint);
+            let albl: $uint = (a_lo as $uint) * (b_lo as $uint);
+
+            let (albl_hi, albl_lo) = split_uint_halves(albl);
+
+            albh += albl_hi as $uint;
+            debug_assert!(albh >= albl_hi as $uint);
+
+            let (albh, overflow) = albh.overflowing_add(ahbl);
+            if overflow {
+                ahbh = ahbh.wrapping_add(UINT_H_BASE);
+            }
+
+            (
+                ahbh.wrapping_add(albh >> UINT_H_BITS),
+                (albl_lo as $uint).wrapping_add(albh << UINT_H_BITS),
+            )
+        }
+    };
+}
+
+// macro_rules! define_mul2 {
+//     // mul2(), mul2_halves() implement
+//     //
+//     //      a * b -> (hi, lo)
+//     //
+//     //      where a, b, hi, lo are all of type uint.
+//     //
+//     // They are equivalent in behavior.
+//     //
+//     // uint     : primitive unsigned integer type (e.g. u128).
+//     // uint_h   : primitive unsigned integer type with size in bits half that
+//     //            of uint.
+//     ($uint:ty, $uint_h:ty) => {
+
+// const UINT_BITS: u32 = <$uint>::BITS;
+// const UINT_H_BITS: u32 = UINT_BITS >> 1;
+// const UINT_H_BASE: $uint = 1 as $uint << UINT_H_BITS;
+// const UINT_H_MAX: $uint = UINT_H_BASE - 1; // MASK for low part of UINT
+
+// #[inline(always)]
+// #[allow(dead_code)]
+// const fn split_uint(x: $uint) -> ($uint, $uint) {
+//     let hi = x >> UINT_H_BITS;
+//     let lo = x & UINT_H_MAX;
+//     (hi, lo)
+// }
+
+// #[inline(always)]
+// const fn split_uint_halves(x: $uint) -> ($uint_h, $uint_h) {
+//     let hi = (x >> UINT_H_BITS) as $uint_h;
+//     let lo = (x & UINT_H_MAX) as $uint_h;
+//     (hi, lo)
+// }
+
+// #[inline]
+// #[allow(dead_code)]
+// pub(crate) const fn mul2(a: $uint, b: $uint) -> ($uint, $uint) {
+//     let (a_hi, a_lo) = split_uint(a);
+//     let (b_hi, b_lo) = split_uint(b);
+
+//     let mut ahbh = a_hi * b_hi;
+//     let ahbl = a_hi * b_lo;
+//     let mut albh = a_lo * b_hi;
+//     let albl = a_lo * b_lo;
+
+//     let (albl_hi, albl_lo) = split_uint(albl);
+
+//     albh += albl_hi;
+//     debug_assert!(albh >= albl_hi);
+
+//     let (albh, overflow) = albh.overflowing_add(ahbl);
+//     if overflow {
+//         ahbh = ahbh.wrapping_add(UINT_H_BASE);
+//     }
+
+//     (
+//         ahbh.wrapping_add(albh >> UINT_H_BITS),
+//         albl_lo.wrapping_add(albh << UINT_H_BITS),
+//     )
+// }
+
+// #[inline]
+// pub(crate) const fn mul2_halves(a: $uint, b: $uint) -> ($uint, $uint) {
+//     let (a_hi, a_lo) = split_uint_halves(a);
+//     let (b_hi, b_lo) = split_uint_halves(b);
+
+//     let mut ahbh: $uint = (a_hi as $uint) * (b_hi as $uint);
+//     let ahbl: $uint = (a_hi as $uint) * (b_lo as $uint);
+//     let mut albh: $uint = (a_lo as $uint) * (b_hi as $uint);
+//     let albl: $uint = (a_lo as $uint) * (b_lo as $uint);
+
+//     let (albl_hi, albl_lo) = split_uint_halves(albl);
+
+//     albh += albl_hi as $uint;
+//     debug_assert!(albh >= albl_hi as $uint);
+
+//     let (albh, overflow) = albh.overflowing_add(ahbl);
+//     if overflow {
+//         ahbh = ahbh.wrapping_add(UINT_H_BASE);
+//     }
+
+//     (
+//         ahbh.wrapping_add(albh >> UINT_H_BITS),
+//         (albl_lo as $uint).wrapping_add(albh << UINT_H_BITS),
+//     )
+// }
+
+//     };
+// }
 
 pub(crate) mod u128_impl {
     define_mul2!(u128, u64);
@@ -100,6 +190,10 @@ pub(crate) mod u128_impl {
 #[allow(dead_code)]
 mod u64_impl {
     define_mul2!(u64, u32);
+}
+
+pub(crate) mod usize_impl {
+    define_mul2!(usize);
 }
 
 /* TODO: clean up and reduce repetition */

--- a/arbi/src/util/mul.rs
+++ b/arbi/src/util/mul.rs
@@ -3,13 +3,13 @@ Copyright 2025 Owain Davies
 SPDX-License-Identifier: Apache-2.0 OR MIT
 */
 
-macro_rules! define_mul2_internal {
-    // Internal macro that defines the common parts
+macro_rules! define_mul2_common {
+    /* Common parts */
     ($uint:ty) => {
         const UINT_BITS: u32 = <$uint>::BITS;
         const UINT_H_BITS: u32 = UINT_BITS >> 1;
         const UINT_H_BASE: $uint = 1 as $uint << UINT_H_BITS;
-        const UINT_H_MAX: $uint = UINT_H_BASE - 1;
+        const UINT_H_MAX: $uint = UINT_H_BASE - 1; // MASK for low part of UINT
 
         #[inline(always)]
         #[allow(dead_code)]
@@ -19,7 +19,7 @@ macro_rules! define_mul2_internal {
             (hi, lo)
         }
 
-        #[inline]
+        #[inline(always)]
         #[allow(dead_code)]
         pub(crate) const fn mul2(a: $uint, b: $uint) -> ($uint, $uint) {
             let (a_hi, a_lo) = split_uint(a);
@@ -49,14 +49,25 @@ macro_rules! define_mul2_internal {
 }
 
 macro_rules! define_mul2 {
-    // Single parameter version - only defines mul2()
+    // Defines only mul2()
     ($uint:ty) => {
-        define_mul2_internal!($uint);
+        define_mul2_common!($uint);
     };
 
-    // Two parameter version - adds mul2_halves()
+    // Defines both mul2(), mul2_halves()
+    // mul2(), mul2_halves() implement
+    //
+    //      a * b -> (hi, lo)
+    //
+    //      where a, b, hi, lo are all of type uint.
+    //
+    // They are equivalent in behavior.
+    //
+    // uint     : primitive unsigned integer type (e.g. u128).
+    // uint_h   : primitive unsigned integer type with size in bits half that
+    //            of uint.
     ($uint:ty, $uint_h:ty) => {
-        define_mul2_internal!($uint);
+        define_mul2_common!($uint);
 
         #[inline(always)]
         const fn split_uint_halves(x: $uint) -> ($uint_h, $uint_h) {
@@ -65,7 +76,7 @@ macro_rules! define_mul2 {
             (hi, lo)
         }
 
-        #[inline]
+        #[inline(always)]
         pub(crate) const fn mul2_halves(a: $uint, b: $uint) -> ($uint, $uint) {
             let (a_hi, a_lo) = split_uint_halves(a);
             let (b_hi, b_lo) = split_uint_halves(b);
@@ -92,96 +103,6 @@ macro_rules! define_mul2 {
         }
     };
 }
-
-// macro_rules! define_mul2 {
-//     // mul2(), mul2_halves() implement
-//     //
-//     //      a * b -> (hi, lo)
-//     //
-//     //      where a, b, hi, lo are all of type uint.
-//     //
-//     // They are equivalent in behavior.
-//     //
-//     // uint     : primitive unsigned integer type (e.g. u128).
-//     // uint_h   : primitive unsigned integer type with size in bits half that
-//     //            of uint.
-//     ($uint:ty, $uint_h:ty) => {
-
-// const UINT_BITS: u32 = <$uint>::BITS;
-// const UINT_H_BITS: u32 = UINT_BITS >> 1;
-// const UINT_H_BASE: $uint = 1 as $uint << UINT_H_BITS;
-// const UINT_H_MAX: $uint = UINT_H_BASE - 1; // MASK for low part of UINT
-
-// #[inline(always)]
-// #[allow(dead_code)]
-// const fn split_uint(x: $uint) -> ($uint, $uint) {
-//     let hi = x >> UINT_H_BITS;
-//     let lo = x & UINT_H_MAX;
-//     (hi, lo)
-// }
-
-// #[inline(always)]
-// const fn split_uint_halves(x: $uint) -> ($uint_h, $uint_h) {
-//     let hi = (x >> UINT_H_BITS) as $uint_h;
-//     let lo = (x & UINT_H_MAX) as $uint_h;
-//     (hi, lo)
-// }
-
-// #[inline]
-// #[allow(dead_code)]
-// pub(crate) const fn mul2(a: $uint, b: $uint) -> ($uint, $uint) {
-//     let (a_hi, a_lo) = split_uint(a);
-//     let (b_hi, b_lo) = split_uint(b);
-
-//     let mut ahbh = a_hi * b_hi;
-//     let ahbl = a_hi * b_lo;
-//     let mut albh = a_lo * b_hi;
-//     let albl = a_lo * b_lo;
-
-//     let (albl_hi, albl_lo) = split_uint(albl);
-
-//     albh += albl_hi;
-//     debug_assert!(albh >= albl_hi);
-
-//     let (albh, overflow) = albh.overflowing_add(ahbl);
-//     if overflow {
-//         ahbh = ahbh.wrapping_add(UINT_H_BASE);
-//     }
-
-//     (
-//         ahbh.wrapping_add(albh >> UINT_H_BITS),
-//         albl_lo.wrapping_add(albh << UINT_H_BITS),
-//     )
-// }
-
-// #[inline]
-// pub(crate) const fn mul2_halves(a: $uint, b: $uint) -> ($uint, $uint) {
-//     let (a_hi, a_lo) = split_uint_halves(a);
-//     let (b_hi, b_lo) = split_uint_halves(b);
-
-//     let mut ahbh: $uint = (a_hi as $uint) * (b_hi as $uint);
-//     let ahbl: $uint = (a_hi as $uint) * (b_lo as $uint);
-//     let mut albh: $uint = (a_lo as $uint) * (b_hi as $uint);
-//     let albl: $uint = (a_lo as $uint) * (b_lo as $uint);
-
-//     let (albl_hi, albl_lo) = split_uint_halves(albl);
-
-//     albh += albl_hi as $uint;
-//     debug_assert!(albh >= albl_hi as $uint);
-
-//     let (albh, overflow) = albh.overflowing_add(ahbl);
-//     if overflow {
-//         ahbh = ahbh.wrapping_add(UINT_H_BASE);
-//     }
-
-//     (
-//         ahbh.wrapping_add(albh >> UINT_H_BITS),
-//         (albl_lo as $uint).wrapping_add(albh << UINT_H_BITS),
-//     )
-// }
-
-//     };
-// }
 
 pub(crate) mod u128_impl {
     define_mul2!(u128, u64);


### PR DESCRIPTION
This leads to a very significant speedup for bases 2 (`0b10`), 4 (`0b100`), 8 (`0b1000`), 16 (`0b10000`), and 32 (`0b100000`).

This PR also does a few more things, which probably should have been done independently from this PR.

- Ensures that `from`/`assign`-`str` functions never preallocate more than one more than the number of `Arbi::BASE` digits actually needed to store the number the string represents. The initial calculation involving `div_ceil()` is great for small strings, but for very large strings, it may lead to an overallocation by hundreds or even thousands of `Arbi::BASE` digits. This applies for all valid bases `[2, 36]`.
- Fixes a bug in `size_base()`-type functions that used `> 0` instead of `!= 0` when dividing an `Arbi` integer in-place to determine the number of base-`base` digits. `!= 0` is needed, rather than `> 0 `, in case the `Arbi` integer is negative.